### PR TITLE
Design: 팀 페이지 - 칸반보드 UI 구조

### DIFF
--- a/public/check.svg
+++ b/public/check.svg
@@ -1,0 +1,6 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Group 40279">
+<circle id="Ellipse 35" cx="10" cy="10" r="9.5" stroke="black"/>
+<path id="Vector 569" d="M7 10.6923L9.21053 13L14 8" stroke="black"/>
+</g>
+</svg>

--- a/public/profile.svg
+++ b/public/profile.svg
@@ -1,0 +1,13 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Group 40276">
+<circle id="Ellipse 24" cx="12" cy="12" r="12" fill="#5F5F5F"/>
+<g id="Mask group">
+<mask id="mask0_57_2706" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="24" height="24">
+<circle id="Ellipse 21" cx="12" cy="12" r="12" fill="#4D4D4D"/>
+</mask>
+<g mask="url(#mask0_57_2706)">
+<path id="Union" fill-rule="evenodd" clip-rule="evenodd" d="M13.9259 12.84C15.1623 12.1596 16 10.8443 16 9.33331C16 7.12417 14.2092 5.33331 12 5.33331C9.7909 5.33331 8.00004 7.12417 8.00004 9.33331C8.00004 10.8443 8.83783 12.1596 10.0742 12.84C5.10243 13.7466 1.33337 18.0998 1.33337 23.3333C1.33337 29.2243 6.109 34 12 34C17.8911 34 22.6667 29.2243 22.6667 23.3333C22.6667 18.0998 18.8977 13.7466 13.9259 12.84Z" fill="#D9D9D9"/>
+</g>
+</g>
+</g>
+</svg>

--- a/src/components/issue/IssueCards.tsx
+++ b/src/components/issue/IssueCards.tsx
@@ -1,0 +1,20 @@
+import TaskCards from './TaskCards';
+
+function IssueCard() {
+  return (
+    <div className="flex flex-col gap-[2.4rem] bg-[#F6F6F6] px-[2.3rem] py-[2.8rem]">
+      <span className="text-[1.6rem] text-[#A1A1A1]">할 일 1</span>
+      <TaskCards />
+    </div>
+  );
+}
+
+export default function IssueCards() {
+  return (
+    <div className="flex gap-[2.3rem]">
+      <IssueCard />
+      <IssueCard />
+      <IssueCard />
+    </div>
+  );
+}

--- a/src/components/issue/IssueCards.tsx
+++ b/src/components/issue/IssueCards.tsx
@@ -2,7 +2,7 @@ import TaskCards from './TaskCards';
 
 function IssueCard() {
   return (
-    <div className="flex flex-col gap-[2.4rem] bg-[#F6F6F6] px-[2.3rem] py-[2.8rem]">
+    <div className="flex h-full flex-col gap-[2.4rem] bg-[#F6F6F6] px-[2.3rem] py-[2.8rem]">
       <span className="text-[1.6rem] text-[#A1A1A1]">할 일 1</span>
       <TaskCards />
     </div>
@@ -11,7 +11,7 @@ function IssueCard() {
 
 export default function IssueCards() {
   return (
-    <div className="flex gap-[2.3rem]">
+    <div className="flex h-full w-full justify-between gap-[2.3rem]">
       <IssueCard />
       <IssueCard />
       <IssueCard />

--- a/src/components/issue/KanbanBoard.tsx
+++ b/src/components/issue/KanbanBoard.tsx
@@ -1,0 +1,16 @@
+import IssueCards from './IssueCards';
+
+export default function KanbanBoard() {
+  return (
+    <div className="flex h-[110.7rem] w-[113.2rem] flex-col gap-[1rem] border-[0.1rem] border-[#DCDCDC] bg-white p-[2.4rem]">
+      <div className="flex justify-between">
+        <span className="text-[1.6rem]">칸반보드</span>
+        <button className="bg-[#989898] p-[1rem] text-[1.4rem] text-white">+ 이슈 생성</button>
+        {/* 공통 컴포넌트로 교체 예정 */}
+      </div>
+      <div className="h-full">
+        <IssueCards />
+      </div>
+    </div>
+  );
+}

--- a/src/components/issue/TaskCard.tsx
+++ b/src/components/issue/TaskCard.tsx
@@ -1,0 +1,27 @@
+import checkIcon from '../../../public/check.svg';
+import profileImg from '../../../public/profile.svg';
+
+export default function TaskCard() {
+  return (
+    <div className="flex h-[15.1rem] w-[29.6rem] flex-col justify-between border-[0.1rem] border-[#D2D2D2] bg-white p-[2.2rem]">
+      <div className="flex justify-between">
+        <span className="text-[1rem] font-bold">팀1</span>
+        <img src={checkIcon} alt="체크 표시 아이콘" />
+      </div>
+
+      <div>
+        <span className="text-[1.4rem] text-[#A1A1A1]">와이어 프레임 완성</span>
+      </div>
+
+      <div className="flex justify-between">
+        <button className="rounded-[4rem] border-[0.1rem] border-[#DFDFDF] p-[0.6rem] text-[1rem] text-[#A1A1A1]">
+          0.로그인 page
+        </button>
+        <div className="flex">
+          <img className="mr-[-10px]" src={profileImg} alt="프로필 이미지" />
+          <img className="mr-[-10px]" src={profileImg} alt="프로필 이미지" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/issue/TaskCards.tsx
+++ b/src/components/issue/TaskCards.tsx
@@ -1,7 +1,7 @@
 import checkIcon from '../../../public/check.svg';
 import profileImg from '../../../public/profile.svg';
 
-export default function TaskCard() {
+function TaskCard() {
   return (
     <div className="flex h-[15.1rem] w-[29.6rem] flex-col justify-between border-[0.1rem] border-[#D2D2D2] bg-white p-[2.2rem]">
       <div className="flex justify-between">
@@ -22,6 +22,17 @@ export default function TaskCard() {
           <img className="mr-[-10px]" src={profileImg} alt="프로필 이미지" />
         </div>
       </div>
+    </div>
+  );
+}
+
+export default function TaskCards() {
+  return (
+    <div className="flex flex-col gap-[1.5rem]">
+      <TaskCard />
+      <TaskCard />
+      <TaskCard />
+      <TaskCard />
     </div>
   );
 }

--- a/src/pages/TeamsPage.tsx
+++ b/src/pages/TeamsPage.tsx
@@ -1,5 +1,11 @@
+import KanbanBoard from '@/components/issue/KanbanBoard';
+
 const TeamsPage = () => {
-  return <div>여기는 팀페이지입니다.</div>;
+  return (
+    <div>
+      <KanbanBoard />
+    </div>
+  );
 };
 
 export default TeamsPage;


### PR DESCRIPTION
## 주요 구현 사항 ✨
- 팀 페이지에 들어갈 칸반보드 컴포넌트 UI 구조 잡았습니다.

## 스크린샷 🎨
![image](https://github.com/codeit-part4-8team-project/main/assets/148641571/0f2cc761-6c04-44d7-9694-f3a73b3035cb)


## 구체적 구현 사항 설명 📃
- 아직 와이어프레임 단계라 구조 위주로 잡고 UI적인 것은 신경 많이 안 썼습니다.

## 논의사항 🤔
- 구조를 먼저 잡는 게 목적이었어서 prop이나 state로 관리하는 값은 아직 없습니다.

- 이슈 생성 버튼은 나중에 필겸님이 올려주신 공통 컴포넌트로 교체 예정입니다.
- 프로필 사진 겹쳐진 UI는 다른 곳에서도 많이 쓰여서 나중에 공통 컴포넌트로 분리해도 좋을 것 같습니다.
- 이 컴포넌트는 나중에 이슈 페이지에서 조금만 조정해서 사용할 수 있을 것 같습니다.

- 이미지 에셋들 모아놓는 파일을 src 폴더 안의 assets으로 정하면 어떨까 싶습니다. 소은님이 설정해주신 파일 경로 alias도 src 기준으로 하고 있어서 import 시에도 통일성이 있을 것 같습니다.