### PR TITLE
Feat: 링크 및 모달창 버튼 클릭 이벤트 작업

### DIFF
--- a/src/components/Modal/AnnouncementModal.tsx
+++ b/src/components/Modal/AnnouncementModal.tsx
@@ -3,7 +3,11 @@ import Plus from '../../../public/plus.svg';
 import ModalInput from '../common/ModalInput';
 import ModalLayout from '../common/ModalLayout';
 
-function AnnouncementModal() {
+interface AnnouncementModalProps {
+  closeClick: () => void;
+}
+
+function AnnouncementModal({ closeClick }: AnnouncementModalProps) {
   const [announcemnetValue, setAnnouncemnetValue] = useState('');
   const [memberValue, setMemberValue] = useState('');
   const handleAnnouncementValue = (e: ChangeEvent<HTMLInputElement>) => {
@@ -14,7 +18,12 @@ function AnnouncementModal() {
     setMemberValue(e.target.value);
   };
   return (
-    <ModalLayout title="공지사항 생성" buttonText="이슈 생성" modalName="2024-03-04">
+    <ModalLayout
+      title="공지사항 생성"
+      buttonText="이슈 생성"
+      modalName="2024-03-04"
+      wrong={closeClick}
+    >
       <ModalInput placeholder="공지사항을 입력하세요" value={(e) => handleAnnouncementValue(e)} />
       <div className="mt-[4.7rem] flex text-[2rem]">
         팀원 태그

--- a/src/components/Modal/GroupEditModal.tsx
+++ b/src/components/Modal/GroupEditModal.tsx
@@ -6,9 +6,11 @@ import profile from '../../../public/profile.svg';
 import ModalInput from '../common/ModalInput';
 import ModalLayout from '../common/ModalLayout';
 
+interface GroupEditModalProps {
+  closeClick: () => void;
+}
 
-function GroupEditModal() {
-
+function GroupEditModal({ closeClick }: GroupEditModalProps) {
   const { members } = TeamMembers; // mock team data
   console.log(members); // mock team data
   const { userData } = Mock; // mock user data
@@ -18,7 +20,12 @@ function GroupEditModal() {
   };
   return (
     <>
-      <ModalLayout title="그룹 수정" buttonText="수정 완료" modalName="팀 게시자">
+      <ModalLayout
+        title="그룹 수정"
+        buttonText="수정 완료"
+        modalName="팀 게시자"
+        wrong={closeClick}
+      >
         <div className="mb-24 flex items-center gap-7 text-[1.4rem]">
           {profileImg === 'null' ? <img src={profile} alt="profile" /> : <div>해당이미지</div>}
           {nickName}
@@ -47,6 +54,4 @@ function GroupEditModal() {
   );
 }
 
-
 export default GroupEditModal;
-

--- a/src/components/Modal/GroupModal.tsx
+++ b/src/components/Modal/GroupModal.tsx
@@ -7,7 +7,11 @@ import profile from '../../../public/profile.svg';
 import ModalInput from '../common/ModalInput';
 import ModalLayout from '@/components/common/ModalLayout';
 
-function GroupModal() {
+interface GroupModalProps {
+  closeClick: () => void;
+}
+
+function GroupModal({ closeClick }: GroupModalProps) {
   const [teamNameValue, setTeamNameValue] = useState<string>('');
   const [teamColorValue, setTeamColorValue] = useState('');
   const [memberValue, setMemberValue] = useState('');
@@ -29,7 +33,7 @@ function GroupModal() {
     setMemberValue(e.target.value);
   };
   return (
-    <ModalLayout title="그룹 생성" buttonText="팀 생성" modalName="그룹 게시자">
+    <ModalLayout title="그룹 생성" buttonText="팀 생성" modalName="그룹 게시자" wrong={closeClick}>
       <div className="mb-24 flex items-center gap-7 text-[1.4rem]">
         {profileImg === 'null' ? <img src={profile} alt="profile" /> : <div>해당 이미지</div>}
         {nickName}

--- a/src/components/Modal/IssuesModal.tsx
+++ b/src/components/Modal/IssuesModal.tsx
@@ -3,7 +3,11 @@ import PlusImg from '../../../public/plus.svg';
 import ModalInput from '../common/ModalInput';
 import ModalLayout from '../common/ModalLayout';
 
-function IssuesModal() {
+interface IssuesModalProps {
+  closeClick: () => void;
+}
+
+function IssuesModal({ closeClick }: IssuesModalProps) {
   const [tagValues, setTagValues] = useState('');
   const [members, setMembers] = useState('');
   const handleTagClick = () => {
@@ -19,7 +23,12 @@ function IssuesModal() {
   };
 
   return (
-    <ModalLayout title="이슈 생성" buttonText="이슈 생성" modalName="이슈 게시자">
+    <ModalLayout
+      title="이슈 생성"
+      buttonText="이슈 생성"
+      modalName="이슈 게시자"
+      wrong={closeClick}
+    >
       <ModalInput placeholder="이슈를 입력하세요" />
       <div className="mt-[4.5rem] flex gap-5 text-[2rem]">
         관련태그

--- a/src/components/TeamBar.tsx
+++ b/src/components/TeamBar.tsx
@@ -1,13 +1,27 @@
 import profileImg from '../../public/profile.svg';
 
+const team = {
+  id: 0,
+  name: 'string',
+  description: 'string',
+  members: [
+    {
+      name: 'string',
+      role: 'string',
+      grade: 'string',
+    },
+  ],
+};
+
 export default function TeamBar() {
   return (
     <div className="w-fill left-[26rem] right-0 top-[4.3rem] flex h-[5.8rem] items-center justify-between border-[0.1rem] border-[#eee] bg-white px-[2.4rem] py-[1.1rem]">
-      <span className="text-[1.6rem] font-bold">팀 1</span>
+      <span className="text-[1.6rem] font-bold">{team.name}</span>
       <div className="flex items-center gap-[1.8rem]">
         <div className="flex gap-[1rem]">
-          <div className="h-[1.6rem] w-[1.6rem] bg-[#D9D9D9] text-center">+</div>
+          <button className="h-[1.6rem] w-[1.6rem] bg-[#D9D9D9] text-center">+</button>
           <span>초대</span>
+          {/* TODO 초대 모달 띄우기 */}
         </div>
         <div className="flex">
           <img className="mr-[-10px]" src={profileImg} alt="프로필 이미지" />

--- a/src/components/TeamBar.tsx
+++ b/src/components/TeamBar.tsx
@@ -2,7 +2,7 @@ import profileImg from '../../public/profile.svg';
 
 export default function TeamBar() {
   return (
-    <div className="w-fill flex h-[5.8rem] items-center justify-between border-[0.1rem] border-[#eee] bg-white px-[2.4rem] py-[1.1rem]">
+    <div className="w-fill left-[26rem] right-0 top-[4.3rem] flex h-[5.8rem] items-center justify-between border-[0.1rem] border-[#eee] bg-white px-[2.4rem] py-[1.1rem]">
       <span className="text-[1.6rem] font-bold">팀 1</span>
       <div className="flex items-center gap-[1.8rem]">
         <div className="flex gap-[1rem]">

--- a/src/components/announcement/AnnouncementBoard.tsx
+++ b/src/components/announcement/AnnouncementBoard.tsx
@@ -1,12 +1,25 @@
+import { useState } from 'react';
+import AnnouncementModal from '../Modal/AnnouncementModal';
+import Button from '../common/Button';
 import AnnouncementCards from './AnnouncementCards';
 
 export default function AnnouncementBoard() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleButtonClick = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const handleCloseClick = () => {
+    setIsOpen(false);
+  };
+
   return (
     <div className="flex h-[110.7rem] w-fit flex-col gap-[1rem] border-[0.1rem] border-[#DCDCDC] bg-white p-[2.4rem]">
       <div className="flex justify-between">
         <span className="text-[1.6rem]">팀 공지사항</span>
-        <button className="bg-[#989898] p-[1rem] text-[1.4rem] text-white">+ 게시</button>
-        {/* 공통 컴포넌트로 교체 예정 */}
+        {isOpen && <AnnouncementModal closeClick={handleCloseClick} />}
+        <Button text="게시" submit={handleButtonClick} />
       </div>
       <div className="h-full">
         <AnnouncementCards />

--- a/src/components/announcement/AnnouncementCards.tsx
+++ b/src/components/announcement/AnnouncementCards.tsx
@@ -13,6 +13,7 @@ function AnnouncementCard() {
         </div>
         <div className="flex gap-[0.8rem]">
           <img src={checkIcon} alt="체크 표시 아이콘" />
+          {/* TODO 펼치기 & 닫기 기능 */}
           <img src={closedIcon} alt="닫힘 표시 아이콘" />
         </div>
       </div>

--- a/src/components/common/Nav.tsx
+++ b/src/components/common/Nav.tsx
@@ -1,19 +1,31 @@
-import plusIcon from '../../../public/plus.svg'
+import plusIcon from '../../../public/plus.svg';
+
 function Nav() {
-  const linkStyles = " text-xs text-gray-400   font-extrabold hover:underline rounded-full bg-gray-100 w-9 h-9 px-2 py-4";
-const ProfileAlarmStyles ="text-xs text-gray-300 hover:underline rounded-full bg-gray-700 w-9 h-9 px-1.5 py-2.5";
+  const linkStyles =
+    ' text-xs text-gray-400   font-extrabold hover:underline rounded-full bg-gray-100 w-9 h-9 px-2 py-4';
+  const ProfileAlarmStyles =
+    'text-xs text-gray-300 hover:underline rounded-full bg-gray-700 w-9 h-9 px-1.5 py-2.5';
+
   return (
-    <div className="m-0 flex justify-between items-center bg-white  border-b border-solid border-gray-300">
+    <div className="z-1 fixed left-0 right-0 top-0 m-0 flex items-center justify-between border-b  border-solid border-gray-300 bg-white">
       <div className="flex items-center ">
-        <a href='/' className="text-sm  text-gray-300 font-bold w-10 h-6 ml-28 my-4">Logo</a>
-        <div className=" ml-40 my-2.5">
-          <a href="#" className={`${linkStyles} mr-2.5`}>링크1</a>
-          <a href="#" className={`${linkStyles} mr-2.5`}>링크2</a>
-          <a href="#" className={linkStyles}>링크3</a>
+        <a href="/" className="my-4  ml-28 h-6 w-10 text-sm font-bold text-gray-300">
+          Logo
+        </a>
+        <div className=" my-2.5 ml-40">
+          <a href="#" className={`${linkStyles} mr-2.5`}>
+            링크1
+          </a>
+          <a href="#" className={`${linkStyles} mr-2.5`}>
+            링크2
+          </a>
+          <a href="#" className={linkStyles}>
+            링크3
+          </a>
         </div>
-        <img src={plusIcon} alt="Plus Icon" className= "bg-gray-300 px-1 py-1 ml-4 my-4" />
+        <img src={plusIcon} alt="Plus Icon" className="my-4 ml-4 bg-gray-300 px-1 py-1" />
       </div>
-      <div className="flex items-center my-2.5 mr-6">
+      <div className="my-2.5 mr-6 flex items-center">
         <div className={`${ProfileAlarmStyles} mr-4`}>알림</div>
         <div className={ProfileAlarmStyles}>프로필</div>
       </div>

--- a/src/components/common/SideBar.tsx
+++ b/src/components/common/SideBar.tsx
@@ -1,6 +1,6 @@
 export default function SideBar() {
   return (
-    <div className="h-[97rem] w-[26rem] bg-[#F2F2F2] py-[2.4rem]">
+    <div className="fixed left-0 h-[97rem] w-[26rem] bg-[#F2F2F2] py-[2.4rem]">
       <div className="flex h-[5.8rem] w-full items-center justify-between bg-[#E3E3E3] px-[2.4rem] py-[1.7rem]">
         <div className="flex items-center gap-[1rem]">
           <div className="h-[2.4rem] w-[2.4rem] rounded-full bg-[#5F5F5F]"></div>

--- a/src/components/common/SideBar.tsx
+++ b/src/components/common/SideBar.tsx
@@ -1,47 +1,92 @@
+import { useState } from 'react';
+import GroupEditModal from '../Modal/GroupEditModal';
+import GroupModal from '../Modal/GroupModal';
+
 export default function SideBar() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isEditOpen, setIsEditOpen] = useState(false);
+
+  const handleButtonClick = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const handleEditButtonClick = () => {
+    setIsEditOpen(!isOpen);
+  };
+
+  const handleCloseClick = () => {
+    setIsOpen(false);
+  };
+
+  const handleCloseEditClick = () => {
+    setIsEditOpen(false);
+  };
+
   return (
-    <div className="fixed left-0 h-[97rem] w-[26rem] bg-[#F2F2F2] py-[2.4rem]">
-      <div className="flex h-[5.8rem] w-full items-center justify-between bg-[#E3E3E3] px-[2.4rem] py-[1.7rem]">
-        <div className="flex items-center gap-[1rem]">
-          <div className="h-[2.4rem] w-[2.4rem] rounded-full bg-[#5F5F5F]"></div>
-          <span className="text-[1.4rem]">홍길동</span>
-        </div>
-        <div className="h-[2.4rem] w-[2.4rem] bg-[#D9D9D9] text-center">&gt;</div>
-      </div>
-      <div className="mx-auto mb-[3.5rem] mt-[2.4rem] flex w-[22.8rem] flex-col">
-        <div className="flex h-[4rem] w-full items-center justify-between rounded-md bg-[#E3E3E3] px-[1rem] py-[0.8rem] ">
+    <>
+      {isOpen && <GroupModal closeClick={handleCloseClick} />}
+      {isEditOpen && <GroupEditModal closeClick={handleCloseEditClick} />}
+      <div className="fixed left-0 h-[97rem] w-[26rem] bg-[#F2F2F2] py-[2.4rem]">
+        <div className="flex h-[5.8rem] w-full items-center justify-between bg-[#E3E3E3] px-[2.4rem] py-[1.7rem]">
           <div className="flex items-center gap-[1rem]">
-            <div className="h-[2.4rem] w-[2.4rem] bg-[#D9D9D9] text-center"></div>
-            <div className="text-[1.4rem]">대시보드</div>
+            <div className="h-[2.4rem] w-[2.4rem] rounded-full bg-[#5F5F5F]"></div>
+            <span className="text-[1.4rem]">홍길동</span>
           </div>
-          <div className="h-[2.4rem] w-[2.4rem] bg-[#D9D9D9] text-center">⌄</div>
+          <a href="/myPage/1">
+            <button className="h-[2.4rem] w-[2.4rem] bg-[#D9D9D9] text-center">&gt;</button>
+          </a>
         </div>
-        <div className="text-[#B1B1B1]">
-          <ul>
-            <li className="py-[1.2rem] pl-[4.2rem] text-[1.4rem]">나의 캘린더</li>
-            <li className="py-[1.2rem] pl-[4.2rem] text-[1.4rem]">칸반보드</li>
-            <li className="py-[1.2rem] pl-[4.2rem] text-[1.4rem]">공지사항</li>
-          </ul>
+        <div className="mx-auto mb-[3.5rem] mt-[2.4rem] flex w-[22.8rem] flex-col">
+          <div className="flex h-[4rem] w-full items-center justify-between rounded-md bg-[#E3E3E3] px-[1rem] py-[0.8rem] ">
+            <div className="flex items-center gap-[1rem]">
+              <div className="h-[2.4rem] w-[2.4rem] bg-[#D9D9D9] text-center"></div>
+              <div className="text-[1.4rem]">대시보드</div>
+            </div>
+            <button className="h-[2.4rem] w-[2.4rem] bg-[#D9D9D9] text-center">⌄</button>
+          </div>
+          <div className="text-[#B1B1B1]">
+            <ul>
+              <li className="py-[1.2rem] pl-[4.2rem] text-[1.4rem]">
+                <a href="/schedules/1">나의 캘린더</a>
+              </li>
+              <li className="py-[1.2rem] pl-[4.2rem] text-[1.4rem]">
+                <a href="/myIssues/1">칸반보드</a>
+              </li>
+              <li className="py-[1.2rem] pl-[4.2rem] text-[1.4rem]">
+                <a href="teams/1/posts">공지사항</a>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div className="flex h-[5.8rem] w-full items-center justify-between bg-[#E3E3E3] px-[2.4rem] py-[1.7rem]">
+          <span className="text-[1.4rem] font-bold">그룹</span>
+          <button
+            type="button"
+            onClick={handleButtonClick}
+            className="h-[2.4rem] w-[2.4rem] bg-[#D9D9D9] text-center"
+          >
+            +
+          </button>
+        </div>
+        <div className="mx-auto flex w-[22.8rem] flex-col">
+          <div className="text-[#B1B1B1]">
+            <ul>
+              <li className="flex justify-between py-[1.2rem] pl-[4.2rem] pr-[1.2rem] text-[1.4rem]">
+                <a href="/teams/1">팀 1</a>
+                <button onClick={handleEditButtonClick} className="text-[#D8D8D8]">
+                  수정
+                </button>
+              </li>
+              <li className="flex justify-between py-[1.2rem] pl-[4.2rem] pr-[1.2rem] text-[1.4rem]">
+                <a href="/teams/1">스터디</a>
+                <button onClick={handleEditButtonClick} className="text-[#D8D8D8]">
+                  수정
+                </button>
+              </li>
+            </ul>
+          </div>
         </div>
       </div>
-      <div className="flex h-[5.8rem] w-full items-center justify-between bg-[#E3E3E3] px-[2.4rem] py-[1.7rem]">
-        <span className="text-[1.4rem] font-bold">그룹</span>
-        <div className="h-[2.4rem] w-[2.4rem] bg-[#D9D9D9] text-center">+</div>
-      </div>
-      <div className="mx-auto flex w-[22.8rem] flex-col">
-        <div className="text-[#B1B1B1]">
-          <ul>
-            <li className="flex justify-between py-[1.2rem] pl-[4.2rem] pr-[1.2rem] text-[1.4rem]">
-              <span>팀 1</span>
-              <span className="text-[#D8D8D8]">수정</span>
-            </li>
-            <li className="flex justify-between py-[1.2rem] pl-[4.2rem] pr-[1.2rem] text-[1.4rem]">
-              <span>스터디</span>
-              <span className="text-[#D8D8D8]">수정</span>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </div>
+    </>
   );
 }

--- a/src/components/issue/KanbanBoard.tsx
+++ b/src/components/issue/KanbanBoard.tsx
@@ -1,12 +1,25 @@
+import { useState } from 'react';
+import IssuesModal from '../Modal/IssuesModal';
+import Button from '../common/Button';
 import IssueCards from './IssueCards';
 
 export default function KanbanBoard() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleButtonClick = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const handleCloseClick = () => {
+    setIsOpen(false);
+  };
+
   return (
     <div className="flex h-[110.7rem] w-[113.2rem] flex-col gap-[1rem] border-[0.1rem] border-[#DCDCDC] bg-white p-[2.4rem]">
       <div className="flex justify-between">
         <span className="text-[1.6rem]">칸반보드</span>
-        <button className="bg-[#989898] p-[1rem] text-[1.4rem] text-white">+ 이슈 생성</button>
-        {/* 공통 컴포넌트로 교체 예정 */}
+        {isOpen && <IssuesModal closeClick={handleCloseClick} />}
+        <Button text="이슈 생성" submit={handleButtonClick} />
       </div>
       <div className="h-full">
         <IssueCards />

--- a/src/pages/TeamsPage.tsx
+++ b/src/pages/TeamsPage.tsx
@@ -1,10 +1,14 @@
+import Nav from '@/components/common/Nav';
+import SideBar from '@/components/common/SideBar';
 import TeamBar from '@/components/TeamBar';
 import AnnouncementBoard from '@/components/announcement/AnnouncementBoard';
 import KanbanBoard from '@/components/issue/KanbanBoard';
 
 const TeamsPage = () => {
   return (
-    <div>
+    <div className="relative ml-[26rem] mt-[4.3rem]">
+      <Nav />
+      <SideBar />
       <TeamBar />
       <div className="h-[28.4rem] w-full bg-[#E4E4E4]"></div>
       <div className="mx-auto mt-[-3.2rem] flex w-fit gap-[2.4rem]">


### PR DESCRIPTION
## 주요 구현 사항 ✨
- 네비게이션바 & 사이드바를 추가한 팀 페이지 구조
- 각 버튼마다 링크 / 모달 연결
- 버튼 컴포넌트 공통 컴포넌트로 교체

## 스크린샷 🎨
<img width="1407" alt="image" src="https://github.com/codeit-part4-8team-project/main/assets/148641571/8b7235a5-bd4d-47ee-9c26-f231b575f9b6">

## 구체적 구현 사항 설명 📃
- 스크린샷 참고
- 네비게이션 바, 사이드바는 항상 같은 자리에 있을 수 있도록 `fixed` 속성 추가해주었습니다.
  -> 그래서 각자 작업하시는 페이지 마진값 조정해주시면 될 것 같습니다.

## 논의사항 🤔
- 모달 바깥을 클릭하면 모달을 닫히게 하고 싶은데 계속 타입스크립트에서 막혀서 헤메다 결국 그 부분 빼고 pr 올립니다.
  - 필겸님 모달 컴포넌트 보니까 바깥부분 클릭하면 닫히게 하는 함수를 프롭으로 내려주는 게 있던데 내일 여쭤볼게요! @MoonPillGyeom 
