### PR TITLE
Feat: modal Context, usemodal 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { Route, BrowserRouter as Router, Routes } from 'react-router-dom';
+import { ModalProvider } from './contexts/ModalProvider';
 import MyPage from './pages/MyPage';
 import HomePage from '@/pages/HomePage';
 import MainPage from '@/pages/MainPage';
@@ -12,22 +13,24 @@ import TeamsPostsPage from '@/pages/TeamsPostsPage';
 
 function App() {
   return (
-    <Router>
-      <Routes>
-        <Route path="/" element={<HomePage />} />
-        <Route path="/signin" element={<SigninPage />} />
-        <Route path="/signup" element={<SignupPage />} />
-        <Route path="/main" element={<MainPage />} />
-        <Route path="/schedules/:userId" element={<SchedulesPage />} />
-        <Route path="/myIssues/:userId" element={<MyIssuesPage />} />
-        <Route path="/teams">
-          <Route path=":teamsId/schedules" element={<TeamSchedulesPage />} />
-          <Route path=":teamsId" element={<TeamsPage />} />
-          <Route path=":teamsId/posts" element={<TeamsPostsPage />} />
-        </Route>
-        <Route path="/myPage/:userId" element={<MyPage />} />
-      </Routes>
-    </Router>
+    <ModalProvider>
+      <Router>
+        <Routes>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/signin" element={<SigninPage />} />
+          <Route path="/signup" element={<SignupPage />} />
+          <Route path="/main" element={<MainPage />} />
+          <Route path="/schedules/:userId" element={<SchedulesPage />} />
+          <Route path="/myIssues/:userId" element={<MyIssuesPage />} />
+          <Route path="/teams">
+            <Route path=":teamsId/schedules" element={<TeamSchedulesPage />} />
+            <Route path=":teamsId" element={<TeamsPage />} />
+            <Route path=":teamsId/posts" element={<TeamsPostsPage />} />
+          </Route>
+          <Route path="/myPage/:userId" element={<MyPage />} />
+        </Routes>
+      </Router>
+    </ModalProvider>
   );
 }
 

--- a/src/components/Modal/AlertModal.tsx
+++ b/src/components/Modal/AlertModal.tsx
@@ -1,0 +1,31 @@
+import { ReactNode } from 'react';
+import TextButton from '../common/TextButton';
+
+export default function AlertModal({
+  children,
+  buttonText,
+  buttonClick,
+}: {
+  children: ReactNode;
+  buttonText: string;
+  buttonClick: () => void;
+}) {
+  return (
+    <div className="h-[250px] w-[540px] p-7 sm:h-[220px] sm:w-[327px]">
+      <span className="mt-[80px] flex justify-center text-lg font-medium sm:mt-[53px] sm:text-base">
+        {children}
+      </span>
+      <div className="mt-8 flex justify-end sm:mt-9 sm:justify-center">
+        <TextButton
+          buttonSize="md"
+          textSize="md"
+          color="black"
+          onClick={buttonClick}
+          className="text-white"
+        >
+          {buttonText}
+        </TextButton>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ModalWrapper.tsx
+++ b/src/components/ModalWrapper.tsx
@@ -1,0 +1,49 @@
+import { ReactNode, useEffect, useRef } from 'react';
+
+interface Props {
+  id: string;
+  children: ReactNode;
+  onRemove: (id: string) => void;
+}
+
+function ModalWrapper({ children, id, onRemove }: Props) {
+  const ref = useRef<HTMLDialogElement>(null);
+
+  const handleClickOutside = (e: MouseEvent) => {
+    if (ref.current && ref.current === e.target) {
+      onRemove(id);
+    }
+  };
+
+  const handleKeydownEsc = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      onRemove(id);
+    }
+  };
+
+  useEffect(() => {
+    if (ref.current) {
+      ref.current.showModal();
+      document.addEventListener('keydown', handleKeydownEsc);
+      document.addEventListener('click', handleClickOutside);
+      document.body.style.overflow = 'hidden';
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleKeydownEsc);
+      document.removeEventListener('click', handleClickOutside);
+      document.body.style.overflow = ' auto';
+      if (ref.current) {
+        ref.current.close();
+      }
+    };
+  }, [id]);
+
+  return (
+    <dialog ref={ref} className="_pos-center fixed rounded-lg">
+      {children}
+    </dialog>
+  );
+}
+
+export default ModalWrapper;

--- a/src/components/common/ModalLayout.tsx
+++ b/src/components/common/ModalLayout.tsx
@@ -24,9 +24,7 @@ function ModalLayout({
 }: ModalProps) {
   return (
     <div
-      className={clsx(
-        'fixed right-4 top-0 z-10 flex size-full items-center justify-center bg-black bg-opacity-5',
-      )}
+      className={clsx('flex size-full items-center justify-center bg-black bg-opacity-5')}
       ref={modalRef}
       //onClick={(e) => handleModalOutsideClick(e)}
     >

--- a/src/components/common/TextButton.tsx
+++ b/src/components/common/TextButton.tsx
@@ -1,0 +1,59 @@
+import { ReactNode } from 'react';
+import clsx from 'clsx';
+
+//사이즈 컬러 별로 분기, classname 받아서 부모에서 스타일 추가 가능하도록
+//rest 받으므로 form 외부에서 form과 연결할 때는 button attribute인 form={formid} 그대로 전달
+
+interface ButtonProps {
+  type?: 'submit' | 'reset' | 'button';
+  buttonSize?: 'sm' | 'md' | 'lg';
+  textSize?: 'sm' | 'md' | 'lg';
+  color: 'black';
+  children: ReactNode;
+  onClick: () => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+const TextButton = ({
+  type = 'button',
+  buttonSize = 'md',
+  textSize = 'md',
+  color,
+  children,
+  onClick,
+  disabled = false,
+  className,
+  ...rest
+}: ButtonProps) => {
+  const buttonSizeClasses = clsx({
+    'px-[29.5px] py-[7.5px] md:px-[23.5px] md:py-[6.5px] sm:px-[44px] sm:py-[7px]':
+      buttonSize === 'sm',
+    'px-[46px] py-[14.5px]  sm:px-[56px] sm:py-[12.5px]': buttonSize === 'md',
+    'py-[20.5px] px-[95.5px] sm:px-[84.5px] sm:py-[16.5px]': buttonSize === 'lg',
+  });
+
+  const textSizeClasses = clsx({
+    'text-md sm:text-xs': textSize === 'sm',
+    'text-sm font-bold ': textSize === 'md',
+    'text-lg': textSize === 'lg',
+  });
+
+  const colorClasses = clsx({
+    'rounded-md bg-[#292929]': color === 'black',
+  });
+
+  return (
+    <button
+      type={type}
+      className={clsx(textSizeClasses, colorClasses, buttonSizeClasses, className, 'font-medium')}
+      onClick={onClick}
+      disabled={disabled}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default TextButton;

--- a/src/contexts/ModalProvider.tsx
+++ b/src/contexts/ModalProvider.tsx
@@ -1,0 +1,68 @@
+import { ReactNode, createContext, useCallback, useContext, useMemo, useState } from 'react';
+import ModalWrapper from '@/components/ModalWrapper';
+
+interface ModalMethodType {
+  close: () => void;
+  closeAll: () => void;
+}
+
+type GetModalElementType = (props: ModalMethodType) => ReactNode;
+
+interface ModalContextValue {
+  mount: (id: number, getModalElement: GetModalElementType) => void;
+  unmount: (id: number) => void;
+}
+
+const ModalContext = createContext<ModalContextValue | null>(null);
+
+export const ModalProvider = ({ children }: { children: ReactNode }) => {
+  const [modalsId, setModalsId] = useState<Map<number, GetModalElementType>>(new Map());
+
+  const mount = useCallback((id: number, getModalElement: GetModalElementType) => {
+    setModalsId((prev) => new Map(prev).set(id, getModalElement));
+  }, []);
+
+  const unmount = useCallback((id: number) => {
+    setModalsId((prev) => {
+      const newState = new Map(prev);
+      newState.delete(id);
+      return newState;
+    });
+  }, []);
+
+  const unmountAll = useCallback(() => {
+    setModalsId(new Map());
+  }, []);
+
+  const context = useMemo(() => ({ mount, unmount, unmountAll }), [mount, unmount, unmountAll]);
+
+  return (
+    <ModalContext.Provider value={context}>
+      {children}
+      {[...modalsId.entries()].map(([id, getModalElement]) => (
+        <ModalWrapper key={id} id={String(id)} onRemove={() => unmount(id)}>
+          {getModalElement({ close: () => unmount(id), closeAll: () => unmountAll() })}
+        </ModalWrapper>
+      ))}
+    </ModalContext.Provider>
+  );
+};
+
+export const useModal = () => {
+  const context = useContext(ModalContext);
+
+  if (context === null) {
+    throw new Error('ModalProvider 외부입니다.');
+  }
+
+  const { mount } = context;
+
+  const openModal = useCallback(
+    (getModalElement: GetModalElementType) => {
+      mount(Number(crypto.randomUUID()), getModalElement);
+    },
+    [mount],
+  );
+
+  return openModal;
+};

--- a/src/index.css
+++ b/src/index.css
@@ -12,3 +12,9 @@ body {
   font-size: 62.5%;
   margin: 0;
 }
+
+@layer components {
+  ._pos-center {
+    @apply left-2/4 top-2/4 -translate-x-2/4 -translate-y-2/4;
+  }
+}

--- a/src/pages/SigninPage.tsx
+++ b/src/pages/SigninPage.tsx
@@ -1,6 +1,11 @@
+import AlertModal from '@/components/Modal/AlertModal';
+import GroupEditModal from '@/components/Modal/GroupEditModal';
+import { useModal } from '@/contexts/ModalProvider';
 import { useAxios } from '@/hooks/useAxios';
 
 const SigninPage = () => {
+  //refetch 테스트 코드와 모달 테스트 코드 남겼습니다.
+  console.log('컴포넌트 리렌더링됨');
   const payload = { email: '이메일입니다', password: '비밀번호입니다' };
   const { data, loading, error, fetchData } = useAxios({
     path: '/test/',
@@ -14,15 +19,46 @@ const SigninPage = () => {
     });
   };
   //refetch를 이벤트 핸들러에 포함하여 새 요청을 보냅니다.
-  return (
-    <div>
-      {loading && <p>Loading...</p>}
-      {error && <p>Error: {error.message}</p>}
-      {data && <p>Data: {`${data}`}</p>}
 
-      <button onClick={handleRefetch}>Refetcher</button>
+  const openModal = useModal();
+  const handleClickOpenModal = () => {
+    openModal(({ close }) => <GroupEditModal closeClick={close}></GroupEditModal>);
+  };
+  const handleClickOpenMultiModal = () => {
+    openModal(({ close }) => (
+      <AlertModal buttonClick={close} buttonText="두 번째 모달 닫기">
+        [선택그룹]을 정말 나가시겠습니까?
+        <button
+          className=" bg-teal-700"
+          onClick={() => {
+            openModal(({ close }) => (
+              <AlertModal buttonClick={close} buttonText="세번째 모달 닫기">
+                모달 속 모달
+              </AlertModal>
+            ));
+          }}
+        >
+          모달에서 모달 띄우기
+        </button>
+      </AlertModal>
+    ));
+  };
+
+  return (
+    <div className="flex size-full min-h-screen flex-col items-center">
+      <div>
+        {loading && <p>Loading...</p>}
+        {error && <p>Error: {error.message}</p>}
+        {data && <p>Data: {`${data}`}</p>}
+        <button onClick={handleRefetch}>Refetcher</button>
+      </div>
+      <button className=" bg-teal-700 text-4xl" onClick={handleClickOpenModal}>
+        모달 테스터
+      </button>
+      <button className=" bg-fuchsia-500 text-4xl" onClick={handleClickOpenMultiModal}>
+        모달 속에서 모달 띄우기
+      </button>
     </div>
   );
-  return <div>여기는 로그인페이지입니다.</div>;
 };
 export default SigninPage;


### PR DESCRIPTION
## 주요 구현 사항 ✨
1. modal 컨텐츠와 모달 열기/닫기 제어 함수를 관리하는 `<ModalContext/>`, `useModal` 훅 작성했습니다.
   `<ModalWrapper/>`에 모달 외부 클릭, `esc`키 입력 시 닫기, 화면 중앙정렬, 이벤트리스너 클린업 기능을 분리해두었습니다.

2. 변경 사항 대비하여 모달 내 모달 띄우기, 모달 여러 개 띄우기가 가능하도록 하였습니다.

3. 기존 모달 시스템과 통합가능하도록 하였습니다. 제가 작성한 `<ModalWrapper/>`와 기존에 있던 `<ModalLayout/>`이랑 일부 기능이 겹치는 건 불가피했습니다. 그래도  `closeClick={close}` 만 붙여서 쓸 수 있어요...!
새로 모달컴포넌트 작성할 때는 `<ModalLayout/>` 없이 모달 내부만 작성해서 쓰시면 됩니다

4. 내부에 폼이 들어가는 모달이 아닌 단순 알림용 모달이 필요해서 스케치만 올려두었습니다.
## 스크린샷 🎨
- 제 로그인 페이지에서 확인 하실 수 있도록 해두었습니다. 

## 구체적 구현 사항 설명 📃
모달 사용법
```js
const SigninPage = () => {
  const openModal = useModal();
  const handleClickOpenModal = () => {
    openModal(({ close }) => <GroupEditModal closeClick={close}></GroupEditModal>);
  };

  return (
      <button className=" bg-teal-700 text-4xl" onClick={handleClickOpenModal} />
)};
```
- 현재 있는 것 외에 추가적으로 모달 컴포넌트가 필요하다면 만드신 뒤에 close만 버튼에 보내셔서 사용하시고 내부 폼 제출이나 그런 건 모달 컴포넌트 내에서 작성해서 해결하면 될 것 같습니다. 

## 논의사항 🤔
1. 내부에 메모이제이션 남발해놓은 거 나중에 리팩터링하면서 확인해보겠습니다. 외부에서 모달 사용하는 방식은 변화 없습니다.
