### PR TITLE
Feat: Make MainPage calendar UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+# Ignore pathtonpm-cache
+pathtonpm-cache

--- a/src/components/MainPage/ControlDate.tsx
+++ b/src/components/MainPage/ControlDate.tsx
@@ -1,0 +1,59 @@
+import clsx from 'clsx';
+
+interface Props {
+  nowDate: Date;
+  setNowDate: React.Dispatch<React.SetStateAction<Date>>;
+}
+function ControlDate({ nowDate, setNowDate }: Props) {
+  const Container = clsx('w-full', 'flex', 'flex-start', 'items-center');
+  const Button = clsx(
+    'w-[1.6rem]',
+    'h-[1.6rem]',
+    'text-[#11111]',
+    'border-[0.1rem]',
+    'border-solid',
+    'border-slate-300',
+  );
+  const DateText = `font-bold text-[1.2rem] text-[#292929] font-pretendard w-[15.4rem] h-[1.4rem]`;
+
+  const getWeekRange = (date: Date): [Date, Date] => {
+    const dayOfWeek = date.getDay();
+    const diff = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
+
+    const startDate = new Date(date);
+    startDate.setDate(startDate.getDate() - diff - 1);
+
+    const endDate = new Date(startDate);
+    endDate.setDate(endDate.getDate() + 6);
+
+    return [startDate, endDate];
+  };
+
+  const changeMonth = (change: number) => {
+    const date = new Date(nowDate.getTime());
+    date.setMonth(date.getMonth() + change);
+    setNowDate(date);
+  };
+  const changeWeekCalendar = (change: number) => {
+    const today = new Date(nowDate.getTime());
+    const dayOfWeek = today.getDay();
+    const diff = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
+
+    today.setDate(today.getDate() - diff + 7 * change);
+    setNowDate(today);
+  };
+  const [startDate, endDate] = getWeekRange(nowDate);
+  return (
+    <div className={Container}>
+      <button className={Button} onClick={() => changeMonth(-1)}>{`<<`}</button>
+      <button className={Button} onClick={() => changeWeekCalendar(-1)}>{`<`}</button>
+
+      <h1
+        className={DateText}
+      >{`${startDate.getFullYear()}. ${startDate.getMonth() + 1}. ${startDate.getDate()} ~ ${endDate.getFullYear()}.${endDate.getMonth() + 1}. ${endDate.getDate()}`}</h1>
+      <button className={Button} onClick={() => changeWeekCalendar(1)}>{`>`}</button>
+      <button className={Button} onClick={() => changeMonth(1)}>{`>>`}</button>
+    </div>
+  );
+}
+export default ControlDate;

--- a/src/components/MainPage/DateBox.tsx
+++ b/src/components/MainPage/DateBox.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+
+function DateBox({ nowDate }: { nowDate: Date }) {
+  const [week, setWeek] = useState<Array<[number, Date]>>([]);
+
+  useEffect(() => {
+    const makeWeekArr = (date: Date): Array<[number, Date]> => {
+      const day = date.getDay();
+      const week: Array<[number, Date]> = [];
+      for (let i = 0; i < 7; i++) {
+        const newDate = new Date(date.valueOf() + 86400000 * (i - day));
+        week.push([i, newDate]);
+      }
+      return week;
+    };
+
+    const currentDate = new Date(nowDate.getFullYear(), nowDate.getMonth(), nowDate.getDate());
+    const weekArr = makeWeekArr(currentDate);
+    setWeek(weekArr);
+  }, [nowDate]);
+
+  const getDayOfWeek = (date: Date): string => {
+    const days = ['일', '월', '화', '수', '목', '금', '토'];
+    return days[date.getDay()];
+  };
+
+  const WeekDisplay: React.FC<{ week: Array<[number, Date]> }> = ({ week }) => (
+    <>
+      {week.map(([index, date]) => (
+        <div
+          className="border-r border-solid border-[#E5E5E5] text-center text-[1.4rem] font-bold text-[#A1A1A1] "
+          key={index}
+        >
+          {`  ${date.getMonth() + 1}.${date.getDate()}.`} ({getDayOfWeek(date)})
+        </div>
+      ))}
+    </>
+  );
+
+  return (
+    <>
+      <div className="grid h-[40.6rem] grid-cols-7 gap-2 rounded-[2.4rem]  ">
+        <WeekDisplay week={week} />
+      </div>
+    </>
+  );
+}
+
+export default DateBox;

--- a/src/components/MainPage/MainSchedules.tsx
+++ b/src/components/MainPage/MainSchedules.tsx
@@ -1,0 +1,22 @@
+import { useState } from 'react';
+import ControlDate from '@/components/MainPage/ControlDate';
+import DateBox from '@/components/MainPage/DateBox';
+
+function MainSchedules() {
+  const Container = 'w-full m-[1.5rem] rounded-[2.4rem] shadow';
+  const [nowDate, setNowDate] = useState<Date>(new Date());
+
+  return (
+    <>
+      {' '}
+      <ControlDate nowDate={nowDate} setNowDate={setNowDate} />
+      <div className={Container}>
+        <div>
+          <DateBox nowDate={nowDate} />
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default MainSchedules;

--- a/src/components/Modal/ScheduleModal.tsx
+++ b/src/components/Modal/ScheduleModal.tsx
@@ -4,9 +4,7 @@ import profile from '../../../public/profile.svg';
 import ModalInput from '../common/ModalInput';
 import ModalLayout from '../common/ModalLayout';
 
-
 function ScheduleModal() {
-
   const [scheduleDetail, setScheduleDetail] = useState('');
   const { userData } = Mock; // userMockData
   const [{ userId, profileImg, nickName, birth }] = userData; // userMockData
@@ -36,6 +34,4 @@ function ScheduleModal() {
   );
 }
 
-
 export default ScheduleModal;
-

--- a/src/components/SchedulesPage/AllDay.tsx
+++ b/src/components/SchedulesPage/AllDay.tsx
@@ -24,6 +24,8 @@
 //   ><p>{day.getDate()} </p></div>;
 // }
 // export default AllDay;
+import { useState } from 'react';
+import ScheduleModal from '../Modal/ScheduleModal';
 import clsx from 'clsx';
 
 interface Props {
@@ -36,11 +38,24 @@ interface Props {
 
 function AllDay({ day, nowDate, setNowDate, clickedDate, setClickedDate }: Props) {
   const Container = clsx('w-full flex justify-center items-center ');
-  const DateDay = clsx('text-black text-[1.2rem] font-bold w-[22rem] h-[15rem] text-center', {
-    'bg-[#EDEDED]':
-      day.getDay() === 0 || day.getDay() === 2 || day.getDay() === 4 || day.getDay() === 6, // 월, 수, 금
-    'bg-[#FFF]': day.getDay() === 1 || day.getDay() === 3 || day.getDay() === 5, // 화, 목, 토
-  });
+  const hover = clsx('hover:bg-[#D1D5DB]');
+  const DateDay = clsx(
+    'text-black text-[1.2rem] font-bold w-[22rem] h-[15rem] text-center',
+    {
+      'bg-[#EDEDED]':
+        day.getDay() === 0 || day.getDay() === 2 || day.getDay() === 4 || day.getDay() === 6, // 월, 수, 금
+      'bg-[#FFF]': day.getDay() === 1 || day.getDay() === 3 || day.getDay() === 5, // 화, 목, 토
+    },
+    hover,
+  );
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const openModal = () => {
+    setIsModalOpen(true);
+  };
+  const closeModal = () => {
+    setIsModalOpen(false);
+  };
+
   const clickDate = () => {
     setClickedDate(day);
   };
@@ -53,7 +68,11 @@ function AllDay({ day, nowDate, setNowDate, clickedDate, setClickedDate }: Props
   return (
     <div className={Container} onClick={clickDate}>
       <div>
-        <p className={DateDay}>{`${day.getDate()}(${getWeekDay(day.getDay())})`}</p>
+        <p
+          onClick={openModal}
+          className={DateDay}
+        >{`${day.getDate()}(${getWeekDay(day.getDay())})`}</p>
+        {isModalOpen && <ScheduleModal />}
       </div>
     </div>
   );

--- a/src/components/SchedulesPage/Schedules.tsx
+++ b/src/components/SchedulesPage/Schedules.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from 'react';
 import fileterIcon from '../../../public/images/filter.svg';
+import ScheduleModal from '../Modal/ScheduleModal';
 import Button from '../common/Button';
-import ModalLayout from '../common/ModalLayout';
 import ControlDate from './ControlDate';
 import DateBox from './DateBox';
 import clsx from 'clsx';
@@ -30,7 +30,6 @@ function Schedules({ calendarType }: SchedulesProps) {
     setIsModalOpen(false);
   };
 
-  const handleSubmit = () => {};
   return (
     <div className={Container}>
       <div className={Contents}>
@@ -48,17 +47,7 @@ function Schedules({ calendarType }: SchedulesProps) {
               </>
             )}
             <Button submit={openModal} text="일정생성" />
-            {isModalOpen && (
-              <ModalLayout
-                title="일정 생성"
-                modalName="scheduleModal"
-                modalRef={modalRef}
-                handleModalOutsideClick={handleModalOutsideClick}
-                buttonText="확인"
-                submit={handleSubmit}
-                wrong={closeModal}
-              />
-            )}
+            {isModalOpen && <ScheduleModal />}
           </div>
         </div>
         <div className={clsx('pl-[2.1rem] pr-4')}>

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,5 +1,5 @@
 const MainPage = () => {
-  return <div>여기는 메인페이지입니다.</div>;
+  return <div>메인 페이지 입니다.</div>;
 };
 
 export default MainPage;


### PR DESCRIPTION
## 주요 구현 사항 ✨

-주간 캘린더 완성했습니다. 
-일 주일 단위 이동, 월 단위 이동 가능하게 했습니다. 

## 스크린샷 🎨

-
![image](https://github.com/codeit-part4-8team-project/main/assets/145126857/8454523f-815f-4a95-8a78-4d4422578522)


## 구체적 구현 사항 설명 📃

-지선님께서 로고 다운받아 놓으셨다고 해서 더 세부적인 스타일 요소는 내일 다시 업로드 하겠습니다. 
-내일 모달 기능, nav기능과 같이 PR올리겠습니다! 
-컴포넌트 폴더의 mainpage의  MainSchedules을 import하셔서 사용하면 됩니다. 

## 논의사항 🤔

-혹시 문제점이나 수정사항이 있다면 말씀해주세요! 
