### PR TITLE
Design: 메인 페이지 레이아웃

### DIFF
--- a/src/components/announcement/AnnouncementBoard.tsx
+++ b/src/components/announcement/AnnouncementBoard.tsx
@@ -3,9 +3,9 @@ import AnnouncementCards from './AnnouncementCards';
 
 export default function AnnouncementBoard() {
   return (
-    <div className="flex h-[110.7rem] w-fit flex-col gap-[2.6rem]">
+    <div className="mt-[3.6rem] flex h-full w-fit flex-col gap-[2.6rem]">
       <AnnouncememntNotification />
-      <div className="h-full">
+      <div className="h-full  overflow-scroll">
         <AnnouncementCards />
       </div>
     </div>

--- a/src/components/announcement/AnnouncementCards.tsx
+++ b/src/components/announcement/AnnouncementCards.tsx
@@ -16,7 +16,7 @@ function AnnouncementCard() {
   };
 
   return (
-    <div className="relative flex w-[42.6rem] flex-col gap-[1.7rem] rounded-[2.4rem] bg-[#ECF619] p-[2.4rem]">
+    <div className="relative flex w-full flex-col gap-[1.7rem] rounded-[2.4rem] bg-[#ECF619] p-[2.4rem]">
       <span className="text-[1.4rem] font-bold text-[#292929]">디자인 스터디</span>
       <span className="text-[1.4rem] text-[#292929]">{isOpen ? content : shortened}</span>
       <span className="text-40 text-[#222222] opacity-30">게시 : 2024-03-04</span>
@@ -46,6 +46,7 @@ function AnnouncementCard() {
 export default function AnnouncementCards() {
   return (
     <div className="flex flex-col gap-[2.4rem]">
+      <AnnouncementCard />
       <AnnouncementCard />
       <AnnouncementCard />
       <AnnouncementCard />

--- a/src/components/common/BoardSection.tsx
+++ b/src/components/common/BoardSection.tsx
@@ -1,0 +1,19 @@
+import { ReactNode } from 'react';
+import CalendarIcon from '../../../public/assets/calendar-dark.svg';
+
+interface BoardSection {
+  title: string;
+  children: ReactNode;
+}
+
+export default function BoardSection({ title, children }: BoardSection) {
+  return (
+    <div className="flex h-full flex-col gap-[1.6rem]">
+      <div className="font-rammetto flex items-center gap-[0.9rem] text-[1.8rem] tracking-[-0.036rem] text-[#292929]">
+        <img src={CalendarIcon} alt="캘린더 아이콘" />
+        <span>{title}</span>
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/src/components/common/BoardSection.tsx
+++ b/src/components/common/BoardSection.tsx
@@ -9,7 +9,7 @@ interface BoardSection {
 export default function BoardSection({ title, children }: BoardSection) {
   return (
     <div className="flex h-full flex-col gap-[1.6rem]">
-      <div className="font-rammetto flex items-center gap-[0.9rem] text-[1.8rem] tracking-[-0.036rem] text-[#292929]">
+      <div className="flex items-center gap-[0.9rem] font-rammetto text-[1.8rem] tracking-[-0.036rem] text-[#292929]">
         <img src={CalendarIcon} alt="캘린더 아이콘" />
         <span>{title}</span>
       </div>

--- a/src/components/common/Nav.tsx
+++ b/src/components/common/Nav.tsx
@@ -6,7 +6,7 @@ import plusCircle from '../../../public/assets/plus-circle-dark.svg';
 
 function Nav() {
   return (
-    <div className="z-1 fixed left-0 right-0 top-0 m-0 flex items-center justify-between  bg-[#F7F7F7]">
+    <div className="z-1 fixed left-0 right-0 top-0 z-50 m-0 flex items-center justify-between bg-[#F7F7F7]">
       <div className="mb-[0.8rem] mt-[1.1rem] flex items-center  ">
         <a href="/" className="ml-16 mt-[1.7rem] ">
           <img src={LogoImg} alt="로고 이미지 " />

--- a/src/components/common/SideBar/BoardList.tsx
+++ b/src/components/common/SideBar/BoardList.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
 import clsx from 'clsx';
-import { BOARDS, Boards } from './constants';
+import { BOARDS, Boards } from '@/components/common/sideBar/constants';
 
 interface BoardItemProps {
   boardType: string;

--- a/src/components/kanbanBoard/IssueList.tsx
+++ b/src/components/kanbanBoard/IssueList.tsx
@@ -7,7 +7,7 @@ const profiles = [ProfileImg, ProfileImg, ProfileImg];
 
 function IssueItem() {
   return (
-    <div className="relative rounded-[2.4rem] border border-[#E5E5E5] bg-white p-8">
+    <div className="relative min-h-64 rounded-[2.4rem] border border-[#E5E5E5] bg-white p-8">
       <div className="flex flex-col gap-[1.2rem]">
         <div className="flex items-center gap-4">
           <img src={GreenDop} />

--- a/src/components/kanbanBoard/IssueList.tsx
+++ b/src/components/kanbanBoard/IssueList.tsx
@@ -7,7 +7,7 @@ const profiles = [ProfileImg, ProfileImg, ProfileImg];
 
 function IssueItem() {
   return (
-    <div className="relative h-64 rounded-[2.4rem] border border-[#E5E5E5] bg-white p-8">
+    <div className="relative rounded-[2.4rem] border border-[#E5E5E5] bg-white p-8">
       <div className="flex flex-col gap-[1.2rem]">
         <div className="flex items-center gap-4">
           <img src={GreenDop} />
@@ -32,7 +32,7 @@ function IssueItem() {
 
 export default function IssueList() {
   return (
-    <div className="flex flex-col gap-[1.5rem]">
+    <div className="flex flex-col gap-[1.5rem] overflow-scroll">
       <IssueItem />
       <IssueItem />
       <IssueItem />

--- a/src/components/kanbanBoard/KanbanBoard.tsx
+++ b/src/components/kanbanBoard/KanbanBoard.tsx
@@ -6,7 +6,7 @@ interface KanbanBoardItemProps {
 
 function KanbanBoardItem({ title }: KanbanBoardItemProps) {
   return (
-    <div className="flex flex-col gap-[2.4rem] rounded-[2.4rem] bg-[#FCFCFC] px-12 pt-12 shadow-[0_0_1rem_0_rgba(17,17,17,0.05)]">
+    <div className="flex h-[52.3rem] w-[34.2rem] flex-col gap-[2.4rem] rounded-[2.4rem] bg-[#FCFCFC] px-12 pt-12 shadow-[0_0_1rem_0_rgba(17,17,17,0.05)]">
       <span className="text-[1.6rem] font-bold text-[#5F5F5F]">{title}</span>
       <IssueList />
     </div>
@@ -15,7 +15,7 @@ function KanbanBoardItem({ title }: KanbanBoardItemProps) {
 
 export default function KanbanBoard() {
   return (
-    <div className="flex h-full w-full justify-between gap-[2.4rem]">
+    <div className="flex w-full justify-between gap-[2.4rem]">
       <KanbanBoardItem title="할 일 3" />
       <KanbanBoardItem title="진행 중 1" />
       <KanbanBoardItem title="백로그 1" />

--- a/src/components/kanbanBoard/KanbanBoard.tsx
+++ b/src/components/kanbanBoard/KanbanBoard.tsx
@@ -6,7 +6,7 @@ interface KanbanBoardItemProps {
 
 function KanbanBoardItem({ title }: KanbanBoardItemProps) {
   return (
-    <div className="flex h-full flex-col gap-[2.4rem] rounded-[2.4rem] bg-[#FCFCFC] px-12 pt-12 shadow-[0_0_1rem_0_rgba(17,17,17,0.05)]">
+    <div className="flex flex-col gap-[2.4rem] rounded-[2.4rem] bg-[#FCFCFC] px-12 pt-12 shadow-[0_0_1rem_0_rgba(17,17,17,0.05)]">
       <span className="text-[1.6rem] font-bold text-[#5F5F5F]">{title}</span>
       <IssueList />
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,4 @@
+@import url('https://fonts.googleapis.com/css2?family=Rammetto+One&display=swap');
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -5,12 +6,18 @@
 * {
   box-sizing: border-box;
   margin: 0;
-  font-family: 'Pretendard';
 }
+
 html,
 body {
+  font-family: 'Pretendard';
+  -ms-overflow-style: none;
   font-size: 62.5%;
   margin: 0;
+}
+
+body ::-webkit-scrollbar {
+  display: none;
 }
 
 @layer components {

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,5 +1,29 @@
-const MainPage = () => {
-  return <div>메인 페이지 입니다.</div>;
-};
+import BoardSection from '@/components/common/BoardSection';
+import Nav from '@/components/common/Nav';
+import SideBar from '@/components/common/SideBar/SideBar';
+import AnnouncementBoard from '@/components/announcement/AnnouncementBoard';
+import KanbanBoard from '@/components/kanbanBoard/KanbanBoard';
 
-export default MainPage;
+export default function MainPage() {
+  return (
+    <div className="h-screen w-full bg-[#EFEFEF] pb-[4.4rem] pl-[28.4rem] pr-[2.4rem] pt-[8.2rem]">
+      <Nav />
+      <SideBar />
+      <div className="grid h-full w-full grid-cols-[107.4fr_42.6fr] grid-rows-2 gap-[5.2rem] rounded-[2.4rem] bg-[#F7F7F7] p-12 shadow-[0px_0px_5px_0px_rgba(17,17,17,0.1)]">
+        <BoardSection title="My calendar">
+          <Temp />
+        </BoardSection>
+        <div className="row-span-2">
+          <AnnouncementBoard />
+        </div>
+        <BoardSection title="Kanban board">
+          <KanbanBoard />
+        </BoardSection>
+      </div>
+    </div>
+  );
+}
+
+function Temp() {
+  return <div className="h-full w-full border border-black"></div>;
+}

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -6,10 +6,10 @@ import KanbanBoard from '@/components/kanbanBoard/KanbanBoard';
 
 export default function MainPage() {
   return (
-    <div className="h-screen w-full bg-[#EFEFEF] pb-[4.4rem] pl-[28.4rem] pr-[2.4rem] pt-[8.2rem]">
+    <div className="h-full w-full bg-[#EFEFEF] pb-[4.4rem] pl-[28.4rem] pr-[2.4rem] pt-[8.2rem]">
       <Nav />
       <SideBar />
-      <div className="grid h-full w-full grid-cols-[107.4fr_42.6fr] grid-rows-2 gap-[5.2rem] rounded-[2.4rem] bg-[#F7F7F7] p-12 shadow-[0px_0px_5px_0px_rgba(17,17,17,0.1)]">
+      <div className="grid h-[113rem] w-[161.2rem] grid-cols-[107.4fr_42.6fr] grid-rows-[auto_auto] gap-[5.2rem] rounded-[2.4rem] bg-[#F7F7F7] p-12 shadow-[0px_0px_5px_0px_rgba(17,17,17,0.1)]">
         <BoardSection title="My calendar">
           <Temp />
         </BoardSection>
@@ -25,5 +25,5 @@ export default function MainPage() {
 }
 
 function Temp() {
-  return <div className="h-full w-full border border-black"></div>;
+  return <div className="h-[40.6rem] w-full border border-black"></div>;
 }

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,6 +1,6 @@
 import BoardSection from '@/components/common/BoardSection';
 import Nav from '@/components/common/Nav';
-import SideBar from '@/components/common/SideBar/SideBar';
+import SideBar from '@/components/common/sideBar/SideBar';
 import AnnouncementBoard from '@/components/announcement/AnnouncementBoard';
 import KanbanBoard from '@/components/kanbanBoard/KanbanBoard';
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,9 @@ export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {},
+    fontFamily: {
+      rammetto: ['"Rammetto One"'],
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## 주요 구현 사항 ✨
- `/main` 페이지 ui 구현했습니다.
- Rammetto One 폰트 tailwind.config.js에 추가했습니다.

## 스크린샷 🎨
![image](https://github.com/codeit-part4-8team-project/main/assets/148641571/1d27406d-9dd6-410d-8324-a69f34aa224f)

## 구체적 구현 사항 설명 📃
- 테일윈드에 `font-rammetto` 사용해서 폰트 사용할 수 있습니다.

![image](https://github.com/codeit-part4-8team-project/main/assets/148641571/5bf62a74-316d-4f17-a2f1-ce4cb64618f3) <- Rammetto One 

## 논의사항 🤔
- 일단 현재 나와있는 피그마대로 작업했습니다. 곧 지현님께서 스크롤 필요하지 않도록 로우 높이 비율 조정해주시면 다시 수정하겠습니다.
- 캘린더 부분은 소은님 작업 중이신 컴포넌트라 나중에 합칠 예정입니다.
