### PR TITLE
Feat: 사이드바 - 현재 페이지에 해당하는 버튼에 포커스 ui 적용

### DIFF
--- a/src/components/common/SideBar/BoardList.tsx
+++ b/src/components/common/SideBar/BoardList.tsx
@@ -1,14 +1,16 @@
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import clsx from 'clsx';
 import { BOARDS, Boards } from './constants';
 
 interface BoardItemProps {
   boardType: string;
-  isCurrent?: boolean;
+  pathname: string;
 }
 
-function BoardItem({ boardType, isCurrent }: BoardItemProps) {
+function BoardItem({ boardType, pathname }: BoardItemProps) {
   const { boardName, iconOn, iconOff, link } = BOARDS[boardType as keyof Boards];
+  const isCurrent = pathname === link ? true : false;
+
   return (
     <Link to={link}>
       <button
@@ -29,20 +31,21 @@ function BoardItem({ boardType, isCurrent }: BoardItemProps) {
 }
 
 export default function BoardList() {
-  // TODO isCurrent는 context에서 관리할 수 있겠다
+  const { pathname } = useLocation();
+
   return (
     <ul className="absolute left-[2.4rem] top-40 flex flex-col gap-[1.6rem]">
       <li>
-        <BoardItem boardType="dashboard" isCurrent />
+        <BoardItem boardType="dashboard" pathname={pathname} />
       </li>
       <li>
-        <BoardItem boardType="calendar" />
+        <BoardItem boardType="calendar" pathname={pathname} />
       </li>
       <li>
-        <BoardItem boardType="kanbanboard" />
+        <BoardItem boardType="kanbanboard" pathname={pathname} />
       </li>
       <li>
-        <BoardItem boardType="board" />
+        <BoardItem boardType="board" pathname={pathname} />
       </li>
     </ul>
   );

--- a/src/components/common/SideBar/SideBar.tsx
+++ b/src/components/common/SideBar/SideBar.tsx
@@ -6,10 +6,7 @@ import GroupModal from '../../Modal/GroupModal';
 import ToolTip from '../ToolTip';
 import BoardList from './BoardList';
 import GroupList from './GroupList';
-
-interface SideBarGroupProp {
-  onCreateClick: () => void;
-}
+import { useModal } from '@/contexts/ModalProvider';
 
 export default function SideBar() {
   const [isOpen, setIsOpen] = useState(false);
@@ -24,7 +21,7 @@ export default function SideBar() {
       <div className="fixed bottom-0 left-0 top-[8.2rem] w-[26rem] rounded-tr-3xl bg-[#292929]">
         <ProfileSection />
         <BoardList />
-        <GroupSection onCreateClick={handleToggleModalClick} />
+        <GroupSection />
       </div>
     </>
   );
@@ -41,11 +38,16 @@ function ProfileSection() {
   );
 }
 
-function GroupSection({ onCreateClick }: SideBarGroupProp) {
+function GroupSection() {
+  const openModal = useModal();
+  const handleClickOpenModal = () => {
+    openModal(({ close }) => <GroupModal closeClick={close}></GroupModal>);
+  };
+
   return (
     <div className="relative mt-[47.8rem] flex items-center justify-between bg-[#222222] py-[1.8rem] pl-16 pr-[2.4rem]">
       <span className="text-[1.6rem] font-bold text-[#EDEEDC]">그룹</span>
-      <button className="relative" onClick={onCreateClick}>
+      <button className="relative" onClick={handleClickOpenModal}>
         <img src={CreateIcon} alt="그룹 생성 버튼" />
         <div className="absolute -left-[7.4rem] -top-[5.1rem]">
           <ToolTip />

--- a/src/components/common/SideBar/constants.ts
+++ b/src/components/common/SideBar/constants.ts
@@ -23,7 +23,7 @@ export const BOARDS: Boards = {
     boardName: '대시보드',
     iconOn: BoxOnIcon,
     iconOff: BoxOffIcon,
-    link: '/teams/1',
+    link: '/main',
   },
   calendar: {
     boardName: '나의 캘린더',


### PR DESCRIPTION
## 주요 구현 사항 ✨
- 사이드바에 현재 열려있는 메뉴가 포커스 되도록 했습니다.

## 스크린샷 🎨
![Mar-13-2024 17-20-50](https://github.com/codeit-part4-8team-project/main/assets/148641571/da617c3d-8ee3-4710-bbd1-ccc3dd1e4324)

## 구체적 구현 사항 설명 📃
- 셀프 리뷰로 설명해놓겠습니다.

## 논의사항 🤔
- 컨텍스트 생각하고 있었는데 아까 채빈님이 말씀해주신대로 pathname으로 받아오니 간단하게 해결되었습니다!
