### PR TITLE
Design: 메인 페이지 ui 높이 수정 및 색상 변수 적용

### DIFF
--- a/src/components/announcement/AnnouncementBoard.tsx
+++ b/src/components/announcement/AnnouncementBoard.tsx
@@ -3,11 +3,9 @@ import AnnouncementCards from './AnnouncementCards';
 
 export default function AnnouncementBoard() {
   return (
-    <div className="row-span-2 mt-[3.6rem] flex h-full w-fit flex-col gap-[2.6rem]">
+    <div className="row-span-2 mt-[3.6rem] flex w-fit flex-col gap-[2.6rem]">
       <AnnouncememntNotification />
-      <div className="h-full  overflow-scroll">
-        <AnnouncementCards />
-      </div>
+      <AnnouncementCards />
     </div>
   );
 }

--- a/src/components/announcement/AnnouncementBoard.tsx
+++ b/src/components/announcement/AnnouncementBoard.tsx
@@ -3,7 +3,7 @@ import AnnouncementCards from './AnnouncementCards';
 
 export default function AnnouncementBoard() {
   return (
-    <div className="mt-[3.6rem] flex h-full w-fit flex-col gap-[2.6rem]">
+    <div className="row-span-2 mt-[3.6rem] flex h-full w-fit flex-col gap-[2.6rem]">
       <AnnouncememntNotification />
       <div className="h-full  overflow-scroll">
         <AnnouncementCards />

--- a/src/components/announcement/AnnouncementCards.tsx
+++ b/src/components/announcement/AnnouncementCards.tsx
@@ -45,7 +45,8 @@ function AnnouncementCard() {
 
 export default function AnnouncementCards() {
   return (
-    <div className="flex flex-col gap-[2.4rem]">
+    <div className="flex h-full flex-col gap-[2.4rem] overflow-scroll">
+      <AnnouncementCard />
       <AnnouncementCard />
       <AnnouncementCard />
       <AnnouncementCard />

--- a/src/components/announcement/AnnouncementCards.tsx
+++ b/src/components/announcement/AnnouncementCards.tsx
@@ -17,9 +17,9 @@ function AnnouncementCard() {
 
   return (
     <div className="relative flex w-full flex-col gap-[1.7rem] rounded-[2.4rem] bg-[#ECF619] p-[2.4rem]">
-      <span className="text-[1.4rem] font-bold text-[#292929]">디자인 스터디</span>
-      <span className="text-[1.4rem] text-[#292929]">{isOpen ? content : shortened}</span>
-      <span className="text-40 text-[#222222] opacity-30">게시 : 2024-03-04</span>
+      <span className="text-[1.4rem] font-bold text-gray100">디자인 스터디</span>
+      <span className="text-[1.4rem] text-gray100">{isOpen ? content : shortened}</span>
+      <span className="text-40 text-black opacity-30">게시 : 2024-03-04</span>
       <div className="absolute right-[2.4rem] top-[2.4rem] flex items-center gap-[0.8rem]">
         <button type="button">
           <img className="h-[2.4rem] w-[2.4rem]" src={CheckIcon} alt="체크 버튼" />

--- a/src/components/common/BoardSection.tsx
+++ b/src/components/common/BoardSection.tsx
@@ -3,17 +3,17 @@ import CalendarIcon from '../../../public/assets/calendar-dark.svg';
 
 interface BoardSection {
   title: string;
-  children: ReactNode;
+  content: ReactNode;
 }
 
-export default function BoardSection({ title, children }: BoardSection) {
+export default function BoardSection({ title, content }: BoardSection) {
   return (
     <div className="flex h-full flex-col gap-[1.6rem]">
       <div className="flex items-center gap-[0.9rem] font-rammetto text-[1.8rem] tracking-[-0.036rem] text-[#292929]">
         <img src={CalendarIcon} alt="캘린더 아이콘" />
         <span>{title}</span>
       </div>
-      {children}
+      <div className="h-full">{content}</div>
     </div>
   );
 }

--- a/src/components/common/BoardSection.tsx
+++ b/src/components/common/BoardSection.tsx
@@ -9,7 +9,7 @@ interface BoardSection {
 export default function BoardSection({ title, content }: BoardSection) {
   return (
     <div className="flex h-full flex-col gap-[1.6rem]">
-      <div className="flex items-center gap-[0.9rem] font-rammetto text-[1.8rem] tracking-[-0.036rem] text-[#292929]">
+      <div className="flex items-center gap-[0.9rem] font-rammetto text-[1.8rem] tracking-[-0.036rem] text-gray100">
         <img src={CalendarIcon} alt="캘린더 아이콘" />
         <span>{title}</span>
       </div>

--- a/src/components/common/SideBar/DropDown.tsx
+++ b/src/components/common/SideBar/DropDown.tsx
@@ -25,7 +25,7 @@ function DropDownItem({ children }: DropDownItemProps) {
     <button
       onClick={handleClickOpenModal}
       type="button"
-      className="inline-flex h-[3.7rem] items-center justify-center p-4 text-[1.4rem] font-medium text-[#5F5F5F] hover:bg-[#EAEAEA]"
+      className="inline-flex h-[3.7rem] items-center justify-center p-4 text-[1.4rem] font-medium text-gray80 hover:bg-[#EAEAEA]"
     >
       {children}
     </button>

--- a/src/components/common/SideBar/SideBar.tsx
+++ b/src/components/common/SideBar/SideBar.tsx
@@ -18,7 +18,7 @@ export default function SideBar() {
   return (
     <>
       {isOpen && <GroupModal closeClick={handleToggleModalClick} />}
-      <div className="fixed bottom-0 left-0 top-[8.2rem] w-[26rem] rounded-tr-3xl bg-[#292929]">
+      <div className="fixed bottom-0 left-0 top-[8.2rem] w-[26rem] rounded-tr-3xl bg-gray100">
         <ProfileSection />
         <BoardList />
         <GroupSection />
@@ -45,7 +45,7 @@ function GroupSection() {
   };
 
   return (
-    <div className="relative mt-[47.8rem] flex items-center justify-between bg-[#222222] py-[1.8rem] pl-16 pr-[2.4rem]">
+    <div className="relative mt-[47.8rem] flex items-center justify-between bg-black py-[1.8rem] pl-16 pr-[2.4rem]">
       <span className="text-[1.6rem] font-bold text-[#EDEEDC]">그룹</span>
       <button className="relative" onClick={handleClickOpenModal}>
         <img src={CreateIcon} alt="그룹 생성 버튼" />

--- a/src/components/common/ToolTip.tsx
+++ b/src/components/common/ToolTip.tsx
@@ -3,8 +3,8 @@ import TipArrow from '../../../public/assets/tooltip-arrow.svg';
 export default function ToolTip() {
   return (
     <div className="z-50 flex flex-col items-center">
-      <div className="h-[3.7rem] w-[16.4rem]  rounded-[0.6rem] bg-[#F3FF00] p-4">
-        <span className="text-[1.4rem] font-bold tracking-[-0.02rem] text-[#292929]">
+      <div className="h-[3.7rem] w-[16.4rem]  rounded-[0.6rem] bg-point_yellow p-4">
+        <span className="text-[1.4rem] font-bold tracking-[-0.02rem] text-gray100">
           그룹을 생성하세요!
         </span>
       </div>

--- a/src/components/kanbanBoard/IssueList.tsx
+++ b/src/components/kanbanBoard/IssueList.tsx
@@ -7,20 +7,20 @@ const profiles = [ProfileImg, ProfileImg, ProfileImg];
 
 function IssueItem() {
   return (
-    <div className="relative min-h-64 rounded-[2.4rem] border border-[#E5E5E5] bg-white p-8">
+    <div className="relative min-h-64 rounded-[2.4rem] border border-gray30 bg-white p-8">
       <div className="flex flex-col gap-[1.2rem]">
         <div className="flex items-center gap-4">
           <img src={GreenDop} />
-          <div className="text-[1.2rem] font-bold text-[#292929]">코드잇 프로젝트</div>
+          <div className="text-[1.2rem] font-bold text-gray100">코드잇 프로젝트</div>
         </div>
-        <span className="text-[1.2rem] font-normal leading-[1.6rem] text-[#A1A1A1]">
+        <span className="text-[1.2rem] font-normal leading-[1.6rem] text-gray50">
           프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.
         </span>
       </div>
       <button className="absolute right-8 top-8">
         <img src={CheckIcon} alt="체크 아이콘" />
       </button>
-      <button className="text-4 absolute bottom-8 left-8 flex items-center justify-center rounded-[4rem] border border-[#A1A1A1] px-4 py-[0.6rem] text-[#A1A1A1]">
+      <button className="text-4 absolute bottom-8 left-8 flex items-center justify-center rounded-[4rem] border border-gray50 px-4 py-[0.6rem] text-gray50">
         간단한 자기소개
       </button>
       <div className="absolute bottom-8 right-8">

--- a/src/components/kanbanBoard/IssueList.tsx
+++ b/src/components/kanbanBoard/IssueList.tsx
@@ -32,7 +32,7 @@ function IssueItem() {
 
 export default function IssueList() {
   return (
-    <div className="flex flex-col gap-[1.5rem] overflow-scroll">
+    <div className="flex h-full flex-col gap-[1.5rem] overflow-scroll pb-12">
       <IssueItem />
       <IssueItem />
       <IssueItem />

--- a/src/components/kanbanBoard/KanbanBoard.tsx
+++ b/src/components/kanbanBoard/KanbanBoard.tsx
@@ -7,7 +7,7 @@ interface KanbanBoardItemProps {
 function KanbanBoardItem({ title }: KanbanBoardItemProps) {
   return (
     <div className="flex h-[47.9rem] w-full flex-col gap-[2.4rem] rounded-[2.4rem] bg-[#FCFCFC] px-12 pt-12 shadow-[0_0_1rem_0_rgba(17,17,17,0.05)]">
-      <span className="text-[1.6rem] font-bold text-[#5F5F5F]">{title}</span>
+      <span className="text-[1.6rem] font-bold text-gray80">{title}</span>
       <IssueList />
     </div>
   );

--- a/src/components/kanbanBoard/KanbanBoard.tsx
+++ b/src/components/kanbanBoard/KanbanBoard.tsx
@@ -6,7 +6,7 @@ interface KanbanBoardItemProps {
 
 function KanbanBoardItem({ title }: KanbanBoardItemProps) {
   return (
-    <div className="flex h-[52.3rem] w-[34.2rem] flex-col gap-[2.4rem] rounded-[2.4rem] bg-[#FCFCFC] px-12 pt-12 shadow-[0_0_1rem_0_rgba(17,17,17,0.05)]">
+    <div className="flex h-[47.9rem] w-full flex-col gap-[2.4rem] rounded-[2.4rem] bg-[#FCFCFC] px-12 pt-12 shadow-[0_0_1rem_0_rgba(17,17,17,0.05)]">
       <span className="text-[1.6rem] font-bold text-[#5F5F5F]">{title}</span>
       <IssueList />
     </div>
@@ -15,7 +15,7 @@ function KanbanBoardItem({ title }: KanbanBoardItemProps) {
 
 export default function KanbanBoard() {
   return (
-    <div className="flex w-full justify-between gap-[2.4rem]">
+    <div className="flex h-full w-full justify-between gap-[2.4rem]">
       <KanbanBoardItem title="할 일 3" />
       <KanbanBoardItem title="진행 중 1" />
       <KanbanBoardItem title="백로그 1" />

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -6,10 +6,10 @@ import KanbanBoard from '@/components/kanbanBoard/KanbanBoard';
 
 export default function MainPage() {
   return (
-    <div className="h-screen w-screen bg-[#EFEFEF] pb-[4.4rem] pl-[28.4rem] pr-[2.4rem] pt-[8.2rem]">
+    <div className="h-screen w-screen bg-gray20 pb-[4.4rem] pl-[28.4rem] pr-[2.4rem] pt-[8.2rem]">
       <Nav />
       <SideBar />
-      <div className="grid h-full w-full grid-cols-[107.4fr_37.8fr] grid-rows-[33.7fr_52.5fr] gap-[5.2rem] rounded-[2.4rem] bg-[#F7F7F7] p-12 shadow-[0px_0px_5px_0px_rgba(17,17,17,0.1)]">
+      <div className="grid h-full w-full grid-cols-[107.4fr_37.8fr] grid-rows-[33.7fr_52.5fr] gap-[5.2rem] rounded-[2.4rem] bg-gray10 p-12 shadow-[0px_0px_5px_0px_rgba(17,17,17,0.1)]">
         <BoardSection title="My calendar" content={<Temp />} />
         <AnnouncementBoard />
         <BoardSection title="Kanban board" content={<KanbanBoard />} />

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -11,9 +11,7 @@ export default function MainPage() {
       <SideBar />
       <div className="grid h-[113rem] w-[161.2rem] grid-cols-[107.4fr_42.6fr] grid-rows-[auto_auto] gap-[5.2rem] rounded-[2.4rem] bg-[#F7F7F7] p-12 shadow-[0px_0px_5px_0px_rgba(17,17,17,0.1)]">
         <BoardSection title="My calendar" content={<Temp />} />
-        <div className="row-span-2">
-          <AnnouncementBoard />
-        </div>
+        <AnnouncementBoard />
         <BoardSection title="Kanban board" content={<KanbanBoard />} />
       </div>
     </div>

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -10,15 +10,11 @@ export default function MainPage() {
       <Nav />
       <SideBar />
       <div className="grid h-[113rem] w-[161.2rem] grid-cols-[107.4fr_42.6fr] grid-rows-[auto_auto] gap-[5.2rem] rounded-[2.4rem] bg-[#F7F7F7] p-12 shadow-[0px_0px_5px_0px_rgba(17,17,17,0.1)]">
-        <BoardSection title="My calendar">
-          <Temp />
-        </BoardSection>
+        <BoardSection title="My calendar" content={<Temp />} />
         <div className="row-span-2">
           <AnnouncementBoard />
         </div>
-        <BoardSection title="Kanban board">
-          <KanbanBoard />
-        </BoardSection>
+        <BoardSection title="Kanban board" content={<KanbanBoard />} />
       </div>
     </div>
   );

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -6,10 +6,10 @@ import KanbanBoard from '@/components/kanbanBoard/KanbanBoard';
 
 export default function MainPage() {
   return (
-    <div className="h-full w-full bg-[#EFEFEF] pb-[4.4rem] pl-[28.4rem] pr-[2.4rem] pt-[8.2rem]">
+    <div className="h-screen w-screen bg-[#EFEFEF] pb-[4.4rem] pl-[28.4rem] pr-[2.4rem] pt-[8.2rem]">
       <Nav />
       <SideBar />
-      <div className="grid h-[113rem] w-[161.2rem] grid-cols-[107.4fr_42.6fr] grid-rows-[auto_auto] gap-[5.2rem] rounded-[2.4rem] bg-[#F7F7F7] p-12 shadow-[0px_0px_5px_0px_rgba(17,17,17,0.1)]">
+      <div className="grid h-full w-full grid-cols-[107.4fr_37.8fr] grid-rows-[33.7fr_52.5fr] gap-[5.2rem] rounded-[2.4rem] bg-[#F7F7F7] p-12 shadow-[0px_0px_5px_0px_rgba(17,17,17,0.1)]">
         <BoardSection title="My calendar" content={<Temp />} />
         <AnnouncementBoard />
         <BoardSection title="Kanban board" content={<KanbanBoard />} />
@@ -19,5 +19,5 @@ export default function MainPage() {
 }
 
 function Temp() {
-  return <div className="h-[40.6rem] w-full border border-black"></div>;
+  return <div className="h-[29.1rem] w-full shrink-0 border border-black"></div>;
 }


### PR DESCRIPTION
## 주요 구현 사항 ✨
- 색상 변수 적용
- 1080 화면 사이즈에 맞춘 새로운 디자인에 맞추어 요소 높이 수정

## 스크린샷 🎨
![image](https://github.com/codeit-part4-8team-project/main/assets/148641571/872109e7-dc15-4909-9c9f-e3b67d64f431)

## 구체적 구현 사항 설명 📃
- 스크린샷 참고

## 논의사항 🤔
![image](https://github.com/codeit-part4-8team-project/main/assets/148641571/c666dea7-2715-4c93-9ff8-f42e361c297b)
- 1080 사이즈에 맞추니 전체 화면 사이즈에서는 문제 없는데 브라우저 탭, 북마크 바가 있으면 이렇게 요소들이 아래로 밀려버리면서 레이아웃이 무너져 버리는 문제가 있습니다. 반응형 고려해서 높이 단위에 절대 단위 사용하지 않고 상대 단위 사용하려고 했는데 계속 해결되지 않아서 피그마대로 높이 지정해서 올립니다.
