### PR TITLE
Design: 카드 컴포넌트가 없을 때 보여줄 ui 추가

### DIFF
--- a/src/components/announcement/AnnouncementBoard.tsx
+++ b/src/components/announcement/AnnouncementBoard.tsx
@@ -3,7 +3,7 @@ import AnnouncementCards from './AnnouncementCards';
 
 export default function AnnouncementBoard() {
   return (
-    <div className="mt-[3.6rem] flex h-full w-fit flex-col gap-[2.6rem]">
+    <div className="mt-[3.6rem] flex h-full w-full flex-col gap-[2.6rem]">
       <AnnouncememntNotification />
       <AnnouncementCards />
     </div>

--- a/src/components/announcement/AnnouncementBoard.tsx
+++ b/src/components/announcement/AnnouncementBoard.tsx
@@ -5,9 +5,7 @@ export default function AnnouncementBoard() {
   return (
     <div className="mt-[3.6rem] flex h-full w-fit flex-col gap-[2.6rem]">
       <AnnouncememntNotification />
-      <div className="h-full  overflow-scroll">
-        <AnnouncementCards />
-      </div>
+      <AnnouncementCards />
     </div>
   );
 }

--- a/src/components/announcement/AnnouncementCards.tsx
+++ b/src/components/announcement/AnnouncementCards.tsx
@@ -45,7 +45,7 @@ function AnnouncementCard() {
 
 export default function AnnouncementCards() {
   return (
-    <div className="flex flex-col gap-[2.4rem]">
+    <div className="flex h-full flex-col gap-[2.4rem]  overflow-scroll">
       <AnnouncementCard />
       <AnnouncementCard />
       <AnnouncementCard />

--- a/src/components/announcement/AnnouncementCards.tsx
+++ b/src/components/announcement/AnnouncementCards.tsx
@@ -3,6 +3,7 @@ import ArrowDownIcon from '../../../public/assets/arrow-down-dark.png';
 import CheckIcon from '../../../public/assets/check-circle-dark.svg';
 import CloseIcon from '../../../public/assets/hidden-dark.svg';
 import ProfileImg from '../../../public/assets/profile-small.svg';
+import NoCard from '../common/NoCard';
 
 function AnnouncementCard() {
   const content =
@@ -44,12 +45,20 @@ function AnnouncementCard() {
 }
 
 export default function AnnouncementCards() {
+  const hasCard = false;
+
   return (
-    <div className="flex h-full flex-col gap-[2.4rem]  overflow-scroll">
-      <AnnouncementCard />
-      <AnnouncementCard />
-      <AnnouncementCard />
-      <AnnouncementCard />
+    <div className="flex h-full w-full flex-col gap-[2.4rem] overflow-scroll">
+      {hasCard ? (
+        <>
+          <AnnouncementCard />
+          <AnnouncementCard />
+          <AnnouncementCard />
+          <AnnouncementCard />
+        </>
+      ) : (
+        <NoCard backgroundColor="white">공지사항이 없습니다.</NoCard>
+      )}
     </div>
   );
 }

--- a/src/components/common/NoCard.tsx
+++ b/src/components/common/NoCard.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from 'react';
+
+interface NoCardProps {
+  children: ReactNode;
+  backgroundColor: string;
+}
+
+export default function NoCard({ children, backgroundColor }: NoCardProps) {
+  return (
+    <div
+      className={`relative flex h-64 flex-col items-center justify-center rounded-[2.4rem] bg-${backgroundColor} p-[2.4rem]`}
+    >
+      <span className="text-[1.4rem] font-bold text-gray50">{children}</span>
+    </div>
+  );
+}

--- a/src/components/kanbanBoard/IssueList.tsx
+++ b/src/components/kanbanBoard/IssueList.tsx
@@ -1,6 +1,7 @@
 import CheckIcon from '../../../public/assets/check-circle-dark.svg';
 import GreenDop from '../../../public/assets/green-dot.svg';
 import ProfileImg from '../../../public/assets/profile-small.svg';
+import NoCard from '../common/NoCard';
 import ProfileStack from '../common/ProfileStack';
 
 const profiles = [ProfileImg, ProfileImg, ProfileImg];
@@ -31,12 +32,20 @@ function IssueItem() {
 }
 
 export default function IssueList() {
+  const hasCard = false;
+
   return (
     <div className="flex flex-col gap-[1.5rem] overflow-scroll">
-      <IssueItem />
-      <IssueItem />
-      <IssueItem />
-      <IssueItem />
+      {hasCard ? (
+        <>
+          <IssueItem />
+          <IssueItem />
+          <IssueItem />
+          <IssueItem />
+        </>
+      ) : (
+        <NoCard backgroundColor="[#F6F6F6]">이슈가 없습니다.</NoCard>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 주요 구현 사항 ✨
- 카드 컴포넌트가 없을 때 보여줄 ui 추가 - 공통 컴포넌트로 분리했습니다.

## 스크린샷 🎨
### 공지사항
![image](https://github.com/codeit-part4-8team-project/main/assets/148641571/7bf4874e-fb1a-4b4b-a9ef-90d6e87b5e26)
### 이슈
![image](https://github.com/codeit-part4-8team-project/main/assets/148641571/292601ff-d0af-424e-8b20-8afafab9c103)


## 구체적 구현 사항 설명 📃
### NoCard.tsx
```js
function NoCard({ children, backgroundColor }: NoCardProps) {
  return (
    <div
      className={`relative flex h-64 flex-col items-center justify-center rounded-[2.4rem] bg-${backgroundColor} p-[2.4rem]`}
    >
      <span className="text-[1.4rem] font-bold text-gray50">{children}</span>
    </div>
  );
}
```

### 사용 예시
```js
<NoCard backgroundColor="white">공지사항이 없습니다.</NoCard>
```

## 논의사항 🤔

-
