### PR TITLE
Setting: tailwind Typography 설정

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,91 +15,27 @@ export default {
       point_yellow: '#F3FF00',
       point_red: '#F74242',
     },
+    fontSize: {
+      'body1-bold': ['1.8rem', { lineHeight: '2.6rem', fontWeight: 700 }],
+      'body1-medium': ['1.8rem', { lineHeight: '2.6rem', fontWeight: 500 }],
+      'body1-regular': ['1.8rem', { lineHeight: '2.6rem', fontWeight: 400 }],
+      'body2-bold': ['1.6rem', { lineHeight: '2.4rem', fontWeight: 700 }],
+      'body2-medium': ['1.6rem', { lineHeight: '2.4rem', fontWeight: 500 }],
+      'body2-regular': ['1.6rem', { lineHeight: '2.4rem', fontWeight: 400 }],
+      'body3-bold': ['1.4rem', { lineHeight: '2.2rem', fontWeight: 700 }],
+      'body3-medium': ['1.4rem', { lineHeight: '2.2rem', fontWeight: 500 }],
+      'body3-regular': ['1.4rem', { lineHeight: '2.2rem', fontWeight: 400 }],
+      'body4-bold': ['1.2rem', { lineHeight: '2.0rem', fontWeight: 700 }],
+      'body4-medium': ['1.2rem', { lineHeight: '2.0rem', fontWeight: 500 }],
+      'body4-regular': ['1.2rem', { lineHeight: '2.0rem', fontWeight: 400 }],
+      'body5-bold': ['1.0rem', { lineHeight: '1.8rem', fontWeight: 700 }],
+      'body5-medium': ['1.0rem', { lineHeight: '1.8rem', fontWeight: 500 }],
+      'body5-regular': ['1.0rem', { lineHeight: '1.8rem', fontWeight: 400 }],
+    },
     extend: {},
     fontFamily: {
       rammetto: ['"Rammetto One"'],
     },
   },
-  plugins: [
-    /** @type {import('tailwindcss/types/config').PluginCreator} */
-    ({ addUtilities }) => {
-      addUtilities({
-        '.body1-bold': {
-          'font-size': '1.8rem',
-          'font-weight': 700,
-          'line-height': '2.6rem',
-        },
-        '.body1-medium': {
-          'font-size': '1.8rem',
-          'font-weight': 500,
-          'line-height': '2.6rem',
-        },
-        '.body1-regular': {
-          'font-size': '1.8rem',
-          'font-weight': 400,
-          'line-height': '2.6rem',
-        },
-        '.body2-bold': {
-          'font-size': '1.6rem',
-          'font-weight': 700,
-          'line-height': '2.4rem',
-        },
-        '.body2-medium': {
-          'font-size': '1.6rem',
-          'font-weight': 500,
-          'line-height': '2.4rem',
-        },
-        '.body2-regular': {
-          'font-size': '1.6rem',
-          'font-weight': 400,
-          'line-height': '2.4rem',
-        },
-        '.body3-bold': {
-          'font-size': '1.4rem',
-          'font-weight': 700,
-          'line-height': '2.2rem',
-        },
-        '.body3-medium': {
-          'font-size': '1.4rem',
-          'font-weight': 500,
-          'line-height': '2.2rem',
-        },
-        '.body3-regular': {
-          'font-size': '1.4rem',
-          'font-weight': 400,
-          'line-height': '2.2rem',
-        },
-        '.body4-bold': {
-          'font-size': '1.2rem',
-          'font-weight': 700,
-          'line-height': '2.0rem',
-        },
-        '.body4-medium': {
-          'font-size': '1.2rem',
-          'font-weight': 500,
-          'line-height': '2.0rem',
-        },
-        '.body4-regular': {
-          'font-size': '1.2rem',
-          'font-weight': 400,
-          'line-height': '2.0rem',
-        },
-        '.body5-bold': {
-          'font-size': '1.0rem',
-          'font-weight': 700,
-          'line-height': '1.8rem',
-        },
-        '.body5-medium': {
-          'font-size': '1.0rem',
-          'font-weight': 500,
-          'line-height': '1.8rem',
-        },
-        '.body5-regular': {
-          'font-size': '1.0rem',
-          'font-weight': 400,
-          'line-height': '1.8rem',
-        },
-      });
-    },
-  ],
+  plugins: [],
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 /** @type {import('tailwindcss').Config} */
+
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
@@ -19,5 +20,86 @@ export default {
       rammetto: ['"Rammetto One"'],
     },
   },
-  plugins: [],
+  plugins: [
+    /** @type {import('tailwindcss/types/config').PluginCreator} */
+    ({ addUtilities }) => {
+      addUtilities({
+        '.body1-bold': {
+          'font-size': '1.8rem',
+          'font-weight': 700,
+          'line-height': '2.6rem',
+        },
+        '.body1-medium': {
+          'font-size': '1.8rem',
+          'font-weight': 500,
+          'line-height': '2.6rem',
+        },
+        '.body1-regular': {
+          'font-size': '1.8rem',
+          'font-weight': 400,
+          'line-height': '2.6rem',
+        },
+        '.body2-bold': {
+          'font-size': '1.6rem',
+          'font-weight': 700,
+          'line-height': '2.4rem',
+        },
+        '.body2-medium': {
+          'font-size': '1.6rem',
+          'font-weight': 500,
+          'line-height': '2.4rem',
+        },
+        '.body2-regular': {
+          'font-size': '1.6rem',
+          'font-weight': 400,
+          'line-height': '2.4rem',
+        },
+        '.body3-bold': {
+          'font-size': '1.4rem',
+          'font-weight': 700,
+          'line-height': '2.2rem',
+        },
+        '.body3-medium': {
+          'font-size': '1.4rem',
+          'font-weight': 500,
+          'line-height': '2.2rem',
+        },
+        '.body3-regular': {
+          'font-size': '1.4rem',
+          'font-weight': 400,
+          'line-height': '2.2rem',
+        },
+        '.body4-bold': {
+          'font-size': '1.2rem',
+          'font-weight': 700,
+          'line-height': '2.0rem',
+        },
+        '.body4-medium': {
+          'font-size': '1.2rem',
+          'font-weight': 500,
+          'line-height': '2.0rem',
+        },
+        '.body4-regular': {
+          'font-size': '1.2rem',
+          'font-weight': 400,
+          'line-height': '2.0rem',
+        },
+        '.body5-bold': {
+          'font-size': '1.0rem',
+          'font-weight': 700,
+          'line-height': '1.8rem',
+        },
+        '.body5-medium': {
+          'font-size': '1.0rem',
+          'font-weight': 500,
+          'line-height': '1.8rem',
+        },
+        '.body5-regular': {
+          'font-size': '1.0rem',
+          'font-weight': 400,
+          'line-height': '1.8rem',
+        },
+      });
+    },
+  ],
 };


### PR DESCRIPTION
 ## 주요 구현 사항 ✨
tailwind Typography 설정
폰트 사용시 `text-body1-bold`. 클래스명은 피그마시안 그대로 가져왔습니다.
## 스크린샷 🎨

-

## 구체적 구현 사항 설명 📃
폰트 클래스명 만들고, 에디터에서 자동완성 되도록 해두었습니다.

~~그냥 폰트 클래스명 레이어에 올리면 금방인데 그렇게하면 에디터에서 클래스명 자동완성이 안되길래... 쓰실 때 한참 불편할 것 같아서 intellisense에서 읽을 수 있게 하는 해결법 찾느라 오래걸렸습니다🥲🥲~~

~~혹시 나중에 다른 프로젝트할 때 같은 문제 겪으실 수 있으니
https://tailwindcss.com/docs/plugins
https://github.com/tailwindlabs/tailwindcss-intellisense/issues/227
참고한 링크 붙여드립니다~~

theme에서 속성 여러 개 한번에 조정할 수 있길래 다시 수정했습니다🥲

## 논의사항 🤔

-
