### PR TITLE
메인페이지 캘린더 UI 수정, 모달 캘린더 UI 완성

### DIFF
--- a/src/components/MainPage/MainSchedules.tsx
+++ b/src/components/MainPage/MainSchedules.tsx
@@ -1,19 +1,20 @@
-import CalendarIcon from '../../../public/assets/calendar-dark.svg';
 import ControlDate from '@/components/SchedulesPage/ControlDate';
 import DateBox from '@/components/SchedulesPage/DateBox';
+import CalendarIcon from '@/assets/CalendarIcon';
 
 function MainSchedules() {
-  const Container = 'w-full m-[1.5rem] rounded-[2.4rem]';
+  const Container = 'w-full mt-[1.6rem] rounded-[2.4rem]';
   return (
     <>
-      <div className=" bg-[#F7F7F7]">
-        <div className="flex gap-[67.5rem] whitespace-nowrap">
+      <div className="ml-[0.3rem] mr-[5.2rem] mt-[0.3rem] bg-[#F7F7F7]">
+        <div className="content flex justify-between gap-[120rem]  whitespace-nowrap">
           <div className="flex items-center  gap-[0.9rem] font-rammetto text-[1.8rem] text-[#292929]">
-            <img src={CalendarIcon} alt="캘린더 아이콘" />
-            My calendar
+            <CalendarIcon active={true}></CalendarIcon>
+            <span> My calendar </span>
           </div>
           <ControlDate mode="week" />
         </div>
+
         <div className={Container}>
           <div>
             <DateBox mode="week" />

--- a/src/components/ModalCalenar/ModalCalendar.tsx
+++ b/src/components/ModalCalenar/ModalCalendar.tsx
@@ -1,0 +1,13 @@
+import ControlDate from '../SchedulesPage/ControlDate';
+import DateBox from '../SchedulesPage/DateBox';
+
+function ModalCalendar() {
+  return (
+    <div className="h-full w-full">
+      <ControlDate mode="modal" />
+      <DateBox mode="modal" />
+    </div>
+  );
+}
+
+export default ModalCalendar;

--- a/src/components/SchedulesPage/AllDay.tsx
+++ b/src/components/SchedulesPage/AllDay.tsx
@@ -5,8 +5,9 @@ import { calendarContext } from '@/contexts/CalenarProvider';
 
 interface AllDayProp {
   day: Date;
+  mode: 'month' | 'modal';
 }
-function AllDay({ day }: AllDayProp) {
+function AllDay({ day, mode }: AllDayProp) {
   const { nowDate } = useContext(calendarContext);
   const Container = 'w-full h-full flex justify-center items-center rounded-[2.4rem] border-none  ';
   const hover = 'hover:bg-[#F7F7F7]';
@@ -53,6 +54,15 @@ function AllDay({ day }: AllDayProp) {
       'text-[#F74242]': day.getDay() === 0 && !notThisMonthClass,
     },
   );
+  const modalCell = clsx(
+    'my-[0.2rem] mx-[0.4rem] w-[1.9rem] text-center text-[#A1A1A1] ',
+    hover,
+    todayClass,
+    notThisMonthClass,
+    {
+      'text-[#F74242]': day.getDay() === 0 && !notThisMonthClass,
+    },
+  );
   const [isModalOpen, setIsModalOpen] = useState(false);
   const openModal = () => {
     setIsModalOpen(true);
@@ -62,10 +72,20 @@ function AllDay({ day }: AllDayProp) {
   };
 
   return (
-    <div className={Container}>
-      <p onClick={openModal} className={DateDay}>{` ${day.getDate()} `}</p>
-      {isModalOpen && <ScheduleModal />}
-    </div>
+    <>
+      {mode === 'month' && (
+        <div className={Container}>
+          <p onClick={openModal} className={DateDay}>{` ${day.getDate()} `}</p>
+          {isModalOpen && <ScheduleModal />}
+        </div>
+      )}
+
+      {mode === 'modal' && (
+        <div>
+          <p className={modalCell}>{` ${day.getDate()} `}</p>
+        </div>
+      )}
+    </>
   );
 }
 

--- a/src/components/SchedulesPage/ControlDate.tsx
+++ b/src/components/SchedulesPage/ControlDate.tsx
@@ -7,7 +7,7 @@ import ArrowRight from '../../../public/assets/_allow-right.svg';
 import { calendarContext } from '@/contexts/CalenarProvider';
 
 interface ControlDateProp {
-  mode: 'month' | 'week';
+  mode: 'month' | 'week' | 'modal';
 }
 function ControlDate({ mode }: ControlDateProp) {
   const Container = clsx('w-full', 'flex', 'items-center');
@@ -71,7 +71,7 @@ function ControlDate({ mode }: ControlDateProp) {
       )}
       {mode === 'week' && (
         <div className={Container}>
-          <button className={arrowButton} onClick={() => changeMonth(-1)}>
+          <button className={`${arrowButton} mr-[0.4rem]`} onClick={() => changeMonth(-1)}>
             <img src={ArrowLeftAll} alt="이전 달 이동 아이콘" />
           </button>
           <button className={arrowButton} onClick={() => changeWeekCalendar(-1)}>
@@ -81,11 +81,30 @@ function ControlDate({ mode }: ControlDateProp) {
           <h1
             className={DateText}
           >{`${startDate.getFullYear()}. ${startDate.getMonth() + 1}. ${startDate.getDate()} ~ ${endDate.getFullYear()}.${endDate.getMonth() + 1}. ${endDate.getDate()}`}</h1>
-          <button className={arrowButton} onClick={() => changeWeekCalendar(1)}>
+          <button className={`${arrowButton} mr-[0.4rem]`} onClick={() => changeWeekCalendar(1)}>
             <img src={ArrowRight} alt="다음 주 이동 아이콘" />
           </button>
           <button className={arrowButton} onClick={() => changeMonth(1)}>
             <img src={ArrrowRightAll} alt="다음 달 이동 아이콘" />
+          </button>
+        </div>
+      )}
+      {mode === 'modal' && (
+        <div className={Container}>
+          <button className={`${arrowButton} mr-[0.4rem]`} onClick={() => changeYear(-1)}>
+            <img src={ArrowLeftAll} alt="이전 년도 이동 아이콘" />
+          </button>
+          <button className={arrowButton} onClick={() => changeMonth(-1)}>
+            <img src={ArrowLeft} alt="이전 달 이동 아이콘" />
+          </button>
+
+          <h1 className=" mx-[4rem] w-[4.3rem] whitespace-nowrap text-body5-bold">{`${nowDate.getFullYear()}-${nowDate.getMonth() + 1}`}</h1>
+
+          <button className={arrowButton} onClick={() => changeMonth(1)}>
+            <img src={ArrowRight} alt="다음 달 이동 아이콘" />
+          </button>
+          <button className={`${arrowButton}ml-[0.4rem]`} onClick={() => changeYear(1)}>
+            <img src={ArrrowRightAll} alt="다음 년도 이동 아이콘" />
           </button>
         </div>
       )}

--- a/src/components/SchedulesPage/DateBox.tsx
+++ b/src/components/SchedulesPage/DateBox.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from 'react';
+import { useCallback, useContext, useEffect, useState } from 'react';
 import { makeWeekArr } from '../MainPage/WeekArr';
 import { WeekDisplay } from '../MainPage/WeekDisplay';
 import AllDay from './AllDay';
@@ -6,55 +6,60 @@ import WeekBox from './WeekBox';
 import { calendarContext } from '@/contexts/CalenarProvider';
 
 interface DateBoxProp {
-  mode: 'month' | 'week';
+  mode: 'week' | 'month' | 'modal';
 }
-
 function DateBox({ mode }: DateBoxProp) {
   const [week, setWeek] = useState<Array<[number, Date]>>([]);
   const [allDay, setAllDay] = useState<Date[]>([]);
   const { nowDate } = useContext(calendarContext);
   const weeksStyle = ' text-center text-[#FFF] text-body3-bold bg-[#292929] p-4 ';
 
-  const monthList = (nowDate: Date) => {
-    const nowYear = nowDate.getFullYear();
-    const nowMonth = nowDate.getMonth();
+  const monthList = useCallback(
+    (nowDate: Date) => {
+      const nowYear = nowDate.getFullYear();
+      const nowMonth = nowDate.getMonth();
 
-    const firstDayOfMonth = new Date(nowYear, nowMonth, 1);
-    const lastDayOfMonth = new Date(nowYear, nowMonth + 1, 0);
-    const firstDayOfWeek = firstDayOfMonth.getDay(); // 현재 달의 첫째 날의 요일
+      const firstDayOfMonth = new Date(nowYear, nowMonth, 1);
+      const lastDayOfMonth = new Date(nowYear, nowMonth + 1, 0);
+      const firstDayOfWeek = firstDayOfMonth.getDay(); // 현재 달의 첫째 날의 요일
 
-    // 6주(42일)를 표시하기 위해 필요한 날짜 개수 계산
-    const totalDaysToShow = 42;
+      // 6주(42일)를 표시하기 위해 필요한 날짜 개수 계산
+      const totalDaysToShow = 42;
 
-    const result = Array.from({ length: totalDaysToShow }, (_, i) => {
-      if (i < firstDayOfWeek) {
-        // 이전 달의 날짜
-        return new Date(nowYear, nowMonth, 0 - (firstDayOfWeek - i - 1));
-      } else if (i < firstDayOfWeek + lastDayOfMonth.getDate()) {
-        // 현재 달의 날짜
-        return new Date(nowYear, nowMonth, i - firstDayOfWeek + 1);
-      } else {
-        // 다음 달의 날짜
-        return new Date(nowYear, nowMonth + 1, i - (firstDayOfWeek + lastDayOfMonth.getDate()) + 1);
-      }
-    });
-    return result;
-  };
+      const result = Array.from({ length: totalDaysToShow }, (_, i) => {
+        if (i < firstDayOfWeek) {
+          // 이전 달의 날짜
+          return new Date(nowYear, nowMonth, 0 - (firstDayOfWeek - i - 1));
+        } else if (i < firstDayOfWeek + lastDayOfMonth.getDate()) {
+          // 현재 달의 날짜
+          return new Date(nowYear, nowMonth, i - firstDayOfWeek + 1);
+        } else {
+          // 다음 달의 날짜
+          return new Date(
+            nowYear,
+            nowMonth + 1,
+            i - (firstDayOfWeek + lastDayOfMonth.getDate()) + 1,
+          );
+        }
+      });
+      return result;
+    },
+    [nowDate],
+  );
 
-  const updateDateList = () => {
-    if (mode === 'month') {
+  const updateDateList = useCallback(() => {
+    if (mode === 'month' || 'modal') {
       setAllDay(monthList(nowDate));
     } else if (mode === 'week') {
       const currentDate = new Date(nowDate.getFullYear(), nowDate.getMonth(), nowDate.getDate());
       const weekArray = makeWeekArr(currentDate);
       setWeek(weekArray);
     }
-  };
+  }, [nowDate]);
 
-  // 초기 렌더링 시 한 번 호출
   useEffect(() => {
     updateDateList();
-  }, [updateDateList]);
+  }, []);
 
   const days = ['일', '월', '화', '수', '목', '금', '토'];
 
@@ -62,25 +67,31 @@ function DateBox({ mode }: DateBoxProp) {
     <>
       {mode === 'month' && (
         <div className="grid h-full w-full grid-cols-7 rounded-[2.4rem] ">
-          {days.map((day: string, index: number) => {
-            return (
-              <div
-                key={index}
-                className={`${weeksStyle} ${index === 0 ? 'rounded-tl-[2.4rem] bg-[#F74242]' : ''} ${index === 6 ? 'rounded-tr-[2.4rem]' : ''} `}
-              >
-                <WeekBox weekName={day} />
-              </div>
-            );
-          })}
-
+          {days.map((day: string, index: number) => (
+            <div
+              key={index}
+              className={`${weeksStyle} ${index === 0 ? 'rounded-tl-[2.4rem] bg-[#F74242]' : ''} ${
+                index === 6 ? 'rounded-tr-[2.4rem]' : ''
+              }`}
+            >
+              <WeekBox weekName={day} />
+            </div>
+          ))}
           {allDay.map((day: Date) => (
-            <AllDay key={day.getTime()} day={day} />
+            <AllDay mode="month" key={day.getTime()} day={day} />
           ))}
         </div>
       )}
       {mode === 'week' && (
-        <div className="grid h-[29.1rem] w-full grid-cols-7 rounded-[2.4rem]  bg-[#FCFCFC] shadow-sm  ">
+        <div className="grid h-[29.1rem] w-full grid-cols-7 rounded-[2.4rem] bg-[#FCFCFC] shadow-sm">
           <WeekDisplay week={week} />
+        </div>
+      )}
+      {mode === 'modal' && (
+        <div className="grid h-full w-full grid-cols-7 rounded-[2.4rem]">
+          {allDay.map((day: Date) => (
+            <AllDay mode="modal" key={day.getTime()} day={day} />
+          ))}
         </div>
       )}
     </>

--- a/src/components/SchedulesPage/Schedules.tsx
+++ b/src/components/SchedulesPage/Schedules.tsx
@@ -1,12 +1,11 @@
 import { useRef, useState } from 'react';
 import clsx from 'clsx';
-import MyCalendar from '../../../public/assets/My calendar.svg';
-import CalendarImg from '../../../public/assets/calendar-dark.svg';
 import ScheduleModal from '../Modal/ScheduleModal';
 import Button from '../common/Button';
 import ControlDate from './ControlDate';
 import DateBox from './DateBox';
 import GruoupFilter from './GroupFilter';
+import CalendarIcon from '@/assets/CalendarIcon';
 
 interface SchedulesProps {
   calendarType: string;
@@ -18,7 +17,7 @@ function Schedules({ calendarType }: SchedulesProps) {
   const container =
     'w-[161.2rem] bg-[#F7F7F7] mt-[8.6rem] ml-[28.4rem] mb-[2.4rem]  mr-[2.4rem] pb-[3rem] pt-12 pl-12 pr-[26.9rem] rounded-[2.4rem]';
 
-  const title = clsx('flex item-center');
+  const title = clsx('flex items-center ');
 
   const handleModalOutsideClick = (e: MouseEvent) => {
     if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
@@ -31,14 +30,16 @@ function Schedules({ calendarType }: SchedulesProps) {
   const closeModal = () => {
     setIsModalOpen(false);
   };
-  let calendarsType = calendarType === '나의 캘린더' ? MyCalendar : '';
+  let calendarsType = calendarType === '나의 캘린더' ? 'My Calendar' : 'Team Calendar ';
 
   return (
     <div className={container}>
       <div className="m-0 flex items-center justify-between p-0 ">
         <div className={title}>
-          <img className="mr-4" src={CalendarImg} alt="달력 이미지" />
-          <img className="mr-[2.4rem]" src={calendarsType} />
+          <CalendarIcon active={true} className="mr-4 h-[3.6rem] w-[3.6rem]"></CalendarIcon>
+          <span className="mr-[2.4rem] whitespace-nowrap font-rammetto text-body1-medium">
+            {calendarsType}
+          </span>
           <ControlDate mode="month" />
         </div>
 

--- a/src/components/common/BoardSection.tsx
+++ b/src/components/common/BoardSection.tsx
@@ -9,7 +9,7 @@ interface BoardSection {
 export default function BoardSection({ title, content }: BoardSection) {
   return (
     <div className="flex h-full flex-col gap-[1.6rem]">
-      <div className="text-body1-regular flex items-center gap-[0.9rem] font-rammetto tracking-[-0.036rem] text-gray100">
+      <div className="flex items-center gap-[0.9rem] font-rammetto text-body1-regular tracking-[-0.036rem] text-gray100">
         <img src={CalendarIcon} alt="캘린더 아이콘" />
         <span>{title}</span>
       </div>

--- a/src/contexts/CalenarProvider.tsx
+++ b/src/contexts/CalenarProvider.tsx
@@ -2,14 +2,12 @@ import React, { createContext, useState } from 'react';
 
 export interface CalendarContextType {
   nowDate: Date;
-  mode: 'month' | 'week';
 
   setNowDate: React.Dispatch<React.SetStateAction<Date>>;
 }
 
 const defaultContextValue: CalendarContextType = {
   nowDate: new Date(),
-  mode: 'month',
 
   setNowDate: () => {},
 };
@@ -18,11 +16,9 @@ export const calendarContext = createContext<CalendarContextType>(defaultContext
 
 export const CalendarProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [nowDate, setNowDate] = useState<Date>(new Date());
-  const [mode, setMode] = useState<'month' | 'week'>('month');
 
   const contextValue: CalendarContextType = {
     nowDate,
-    mode,
 
     setNowDate,
   };

--- a/src/pages/TeamSchedulesPage.tsx
+++ b/src/pages/TeamSchedulesPage.tsx
@@ -5,11 +5,11 @@ import Schedules from '@/components/SchedulesPage/Schedules';
 
 const TeamSchedulesPage = () => {
   return (
-    <div className=" h-full w-full bg-[#EFEFEF] pb-[4.1rem] pl-[28.4rem] pr-[2.4rem] pt-[8.6rem]">
+    <div className="bg-[ #EFEFEF] w-[192rem]">
       <Nav />
       <div className={clsx('flex')}>
         <SideBar />
-        <Schedules calendarType="팀의" />
+        <Schedules calendarType="팀 캘린더 " />
       </div>
     </div>
   );


### PR DESCRIPTION
## 주요 구현 사항 ✨

-메인 페이지 캘린더 UI 수정
-모달 캘린더 UI 완료 

## 스크린샷 🎨

-    
![image](https://github.com/codeit-part4-8team-project/main/assets/145126857/0b24d7a6-b4ee-4b96-9346-d1f4c0a79b0c)

## 구체적 구현 사항 설명 📃

`  <div className="h-[20.1rem] w-[22.5rem] px-[1.4rem] py-[1.3rem]">//이부분은 따로 필겸님이 추가해주세요!
        <ModalCalendar />// w,h 둘다 full로 줬습니다. 그냥 import해오셔서 쓰면 될거에요~
      </div>`

## 논의사항 🤔

-메인 페이지  피그마 그대로 적용시 화면에서 이상하게 보여서 제가 gap범위 알아서 수정했습니다. 지현님께 낼 말씀드리겠습니다. 
-필겸님은 한번 모달에 적용해보시면 될 것 같습니다. 
