### PR TITLE
Feat: 소셜로그인 구현 & Refactor: useAxios 타입 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { Route, BrowserRouter as Router, Routes } from 'react-router-dom';
 import { CalendarProvider } from './contexts/CalenarProvider';
 import { ModalProvider } from './contexts/ModalProvider';
 import MyPage from './pages/MyPage';
+import OauthRedirectPage from './pages/OauthRedirectPage';
 import HomePage from '@/pages/HomePage';
 import MainPage from '@/pages/MainPage';
 import MyIssuesPage from '@/pages/MyIssuesPage';
@@ -20,6 +21,7 @@ function App() {
           <Routes>
             <Route path="/" element={<HomePage />} />
             <Route path="/signin" element={<SigninPage />} />
+            <Route path="/login/oauth2/code/:provider" element={<OauthRedirectPage />} />
             <Route path="/signup" element={<SignupPage />} />
             <Route path="/main" element={<MainPage />} />
             <Route path="/schedules/:userId" element={<SchedulesPage />} />

--- a/src/components/SignupPage/EnterUserStepContent.tsx
+++ b/src/components/SignupPage/EnterUserStepContent.tsx
@@ -1,19 +1,133 @@
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+import Input from '../common/Input';
 import TextButton from '../common/TextButton';
+import { useAxios } from '@/hooks/useAxios';
+import { User, UserEditForm } from '@/types/user';
+
+const user = {
+  name: '이채빈',
+  imageUrl: null,
+  username: '이채빈유저네임',
+};
 
 function EnterUserStepContent() {
+  const navigate = useNavigate();
+  const { data, error } = useAxios<User>({
+    method: 'PUT',
+  });
+
+  const {
+    data: isAvailableUsername,
+    error: checkUsernameError,
+    fetchData: checkUsername,
+  } = useAxios<boolean>({
+    path: `user/checkUsername/${user.username}`,
+    method: 'PUT',
+  });
+
+  const {
+    register,
+    handleSubmit,
+    setError,
+    clearErrors,
+    getValues,
+    formState: { isValid, errors },
+  } = useForm<UserEditForm>({
+    mode: 'onChange',
+    defaultValues: {
+      username: user.username,
+    },
+  });
+  const handleCheckUsername = () => {
+    const newUsername = getValues('username');
+    const encodedUsername = encodeURIComponent(newUsername);
+    checkUsername({
+      newPath: `user/checkUsername/${encodedUsername}`,
+    });
+  };
+  const onValid = (data) => {
+    console.log(data);
+  };
+
+  const onInvalid = (error) => {
+    console.log(error);
+  };
+
+  useEffect(() => {
+    if (isAvailableUsername === false) {
+      setError('username', { type: 'manual', message: '이미 사용중인 닉네임입니다.' });
+      console.log(errors.username?.message);
+    } else if (isAvailableUsername === true) {
+      clearErrors('username');
+      console.log(errors.username?.message);
+    }
+    if (checkUsernameError) {
+      console.log(checkUsernameError);
+    }
+  }, [isAvailableUsername, checkUsernameError]);
+
   return (
-    <div className="flex h-[45.9rem] w-[74rem] flex-col pl-[19.2rem] pr-[19.1rem]">
-      <span className="text-[1.4rem] font-medium leading-[2.2rem] text-black">프로필 이미지</span>
-      <div className="mt-4 flex items-center justify-end gap-[5.8rem]">
-        <img src="/public/assets/profile-large.svg" className="" width={66} height={66}></img>
-        <TextButton buttonSize="sm" color="white">
-          프로필 변경
-        </TextButton>
-      </div>
-      <input></input>
-      {/* 필겸님 공통컴포넌트 만드시는걸로 대체 */}
-      <input></input>
-      <input></input>
+    <div className="mb-12 mt-[3.4rem] rounded-[0.6rem] border-[0.1rem] border-solid border-gray30 py-12">
+      <form
+        id="editUser"
+        onSubmit={handleSubmit(onValid, onInvalid)}
+        className="flex w-[74rem] flex-col pl-[19.2rem] pr-[19.1rem]"
+      >
+        <span className="text-[1.4rem] font-medium leading-[2.2rem] text-black">프로필 이미지</span>
+        <div className="mb-[1.1rem] mt-4 flex items-center justify-end gap-[5.8rem]">
+          <img src="/public/assets/profile-large.svg" className="" width={66} height={66}></img>
+          <label htmlFor="profileImg">
+            <TextButton type="button" buttonSize="sm" color="white">
+              프로필 변경
+            </TextButton>
+          </label>
+          <input
+            {...register('imageUrl')}
+            id="profileImg"
+            type="file"
+            className=""
+            accept="image/*"
+          />
+        </div>
+        <div className="flex w-full flex-col gap-8">
+          <Input
+            id="name"
+            name="name"
+            label="성함"
+            type="text"
+            value={user.name}
+            disabled={true}
+          ></Input>
+          <div className="flex gap-[1.2rem]">
+            <Input
+              register={register('username', {
+                required: true,
+              })}
+              id="username"
+              label="닉네임*"
+              type="text"
+              placeholder={user.username}
+            ></Input>
+            <TextButton buttonSize="sm" onClick={handleCheckUsername} className="self-end">
+              중복확인
+            </TextButton>
+          </div>
+          <Input
+            register={register('bio', {
+              maxLength: {
+                value: 20,
+                message: '20자 이하로 작성해주세요',
+              },
+            })}
+            id="bio"
+            label="소개"
+            type="text"
+            placeholder="간단한 자기소개를 입력해주세요."
+          ></Input>
+        </div>
+      </form>
     </div>
   );
 }

--- a/src/components/SignupPage/SignupLayout.tsx
+++ b/src/components/SignupPage/SignupLayout.tsx
@@ -2,16 +2,20 @@ import { ReactNode, useState } from 'react';
 import TextButton from '../common/TextButton';
 
 function SignupLayout({ children }: { children: ReactNode }) {
-  const [step, setStep] = useState(1);
+  const [step, setStep] = useState(2);
   return (
     <div className="flex w-[112rem] basis-[67.7rem] flex-col items-center justify-between rounded-[2.4rem] bg-white px-[19rem]">
-      <div className="text-gray30 mt-12 text-[1.4rem] font-bold leading-[2.4rem]">
+      <div className="mt-12 text-[1.4rem] font-bold leading-[2.4rem] text-gray30">
         <span>약관동의 &gt; </span>
         <span>정보입력 &gt; </span>
         <span>가입완료</span>
       </div>
       {children}
-      <TextButton buttonSize="md" className="mb-[5.4rem]">
+      <TextButton
+        buttonSize="md"
+        className="mb-[5.4rem]"
+        form={step === 2 ? 'editUser' : undefined}
+      >
         {step !== 3 ? '다음 단계' : '지금 바로 시작하기'}
       </TextButton>
     </div>

--- a/src/components/SignupPage/ToSStepContent.tsx
+++ b/src/components/SignupPage/ToSStepContent.tsx
@@ -1,12 +1,26 @@
 import CheckboxInput from './CheckboxInput';
+import AllowDownIcon from '@/assets/AllowDownIcon';
+import BellIcon from '@/assets/BellIcon';
+import BoxIcon from '@/assets/BoxIcon';
+import CalendarIcon from '@/assets/CalendarIcon';
+import Chat4Icon from '@/assets/Chat4Icon';
+import Check2CircleIcon from '@/assets/Check2CircleIcon';
+import CheckCircleFill from '@/assets/CheckCircleFill';
+import FolderIcon from '@/assets/FolderIcon';
+import ListCheckIcon from '@/assets/ListCheckIcon';
+import MeatbollsIcon from '@/assets/MeatbollsIcon';
+import MegaphoneIcon from '@/assets/MegaphoneIcon';
+import PeopleIcon from '@/assets/PeopleIcon';
+import Sliders3Icon from '@/assets/Sliders3Icon';
+import ViewListIcon from '@/assets/ViewListIcon';
 
 function ToSStepContent() {
   return (
     <div className="flex w-[74rem] flex-col">
-      <div className="bg-gray10 mb-[1.6rem] h-[33.2rem] w-full shrink-0 rounded-[0.6rem] py-12 pl-[3.4rem] pr-[2.6rem]">
+      <div className="mb-[1.6rem] h-[33.2rem] w-full shrink-0 rounded-[0.6rem] bg-gray10 py-12 pl-[3.4rem] pr-[2.6rem]">
         <div className="flex items-center gap-[1.6rem]">
           <CheckboxInput id="service"></CheckboxInput>
-          <span className="text-gray100 flex items-center gap-4 text-[1.4rem] font-bold leading-[2.2rem]">
+          <span className="flex items-center gap-4 text-[1.4rem] font-bold leading-[2.2rem] text-gray100">
             <span className="text-[1.2rem] font-normal leading-8">(필수)</span>서비스 이용약관 동의
           </span>
         </div>
@@ -25,7 +39,7 @@ function ToSStepContent() {
         </p>
         <div className="flex items-center gap-[1.6rem]">
           <CheckboxInput id="privacy"></CheckboxInput>
-          <span className="text-gray100 flex items-center gap-4 text-[1.4rem] font-bold leading-[2.2rem]">
+          <span className="flex items-center gap-4 text-[1.4rem] font-bold leading-[2.2rem] text-gray100">
             <span className="text-[1.2rem] font-normal leading-8">(필수)</span>서비스 이용약관 동의
           </span>
         </div>
@@ -45,17 +59,48 @@ function ToSStepContent() {
       </div>
       <div className="ml-16 flex items-center gap-[1.6rem]">
         <CheckboxInput id="marketing"></CheckboxInput>
-        <span className="text-gray100 flex items-center gap-4 text-[1.4rem] font-bold leading-[2.2rem]">
+        <span className="flex items-center gap-4 text-[1.4rem] font-bold leading-[2.2rem] text-gray100">
           <span className="text-[1.2rem] font-normal leading-8">(필수)</span>개인정보 수집 및 이용
           동의
         </span>
       </div>
-      <div className="border-t-gray30 mb-[2.4rem] mt-[2.2rem] h-full border-t-[0.1rem] border-solid"></div>
+      <div className="mb-[2.4rem] mt-[2.2rem] h-full border-t-[0.1rem] border-solid border-t-gray30"></div>
       <div className="ml-16 flex items-center gap-[1.6rem]">
         <CheckboxInput id="agree-all"></CheckboxInput>
-        <span className="text-gray100 flex items-center gap-4 text-[1.4rem] font-bold leading-[2.2rem]">
+        <span className="flex items-center gap-4 text-[1.4rem] font-bold leading-[2.2rem] text-gray100">
           KEEPY-UPPY의 이용약관 및 개인정보 처리방침을 확인하였고, 이에 모두 동의합니다.
         </span>
+        <div>
+          <BellIcon></BellIcon>
+          <CalendarIcon active={true} />
+          <Chat4Icon />
+          <Check2CircleIcon></Check2CircleIcon>
+          <ListCheckIcon />
+          <MegaphoneIcon />
+          <PeopleIcon />
+          <Sliders3Icon />
+          <AllowDownIcon />
+          <MeatbollsIcon />
+        </div>
+        <div className="bg-black">
+          <BellIcon fill="white"></BellIcon>
+          <Chat4Icon fill="white" />
+          <Check2CircleIcon fill="white"></Check2CircleIcon>
+          <ListCheckIcon fill="white" />
+          <MegaphoneIcon fill="white" />
+          <PeopleIcon fill="white" />
+          <Sliders3Icon fill="white" />
+          <AllowDownIcon fill="white" />
+          <MeatbollsIcon fill="white" />
+          <BoxIcon active={true} />
+          <BoxIcon />
+          <CalendarIcon active={true} fill="white" />
+          <CalendarIcon fill="white" />
+          <ViewListIcon active={true} />
+          <ViewListIcon />
+          <FolderIcon active={true} />
+          <FolderIcon />
+        </div>
       </div>
     </div>
   );

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -1,0 +1,41 @@
+import { InputHTMLAttributes } from 'react';
+import { UseFormRegisterReturn } from 'react-hook-form';
+import clsx from 'clsx';
+
+interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  id?: string;
+  label?: string;
+  name?: string;
+  placeholder?: string;
+  className?: string;
+  register?: UseFormRegisterReturn;
+}
+
+export default function Input({ id, name, label, placeholder, className, ...props }: InputProps) {
+  return (
+    <div className="flex w-full flex-col items-start gap-[0.8rem]">
+      {label && (
+        <label htmlFor={id} className="text-body3-medium text-[#000000]">
+          {label}
+        </label>
+      )}
+      <div className="flex h-[4.6rem] w-full">
+        <input
+          id={id}
+          name={name}
+          placeholder={placeholder}
+          className={clsx(
+            'w-full items-center rounded-[0.6rem] border-[0.1rem] border-solid border-gray30 px-[1.8rem] py-[1.2rem] text-body3-regular text-gray100 placeholder:text-[#D2D2D]',
+            className,
+          )}
+          {...props}
+        />
+        {/* {watcher && (
+          <span className="hidden text-body5-regular leading-[2.2rem] peer-data-[invalid]:block">
+            {watcher}
+          </span>
+        )} */}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/OauthRedirectPage.tsx
+++ b/src/pages/OauthRedirectPage.tsx
@@ -1,0 +1,51 @@
+import { useEffect } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useAxios } from '@/hooks/useAxios';
+
+interface OauthLoginResponse {
+  name: string;
+  imageUrl: string;
+  username: string;
+  accessToken: string;
+  refreshToken: string;
+  newAccount: boolean;
+}
+
+const OauthRedirectPage = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { provider } = useParams();
+  const queryParams = new URLSearchParams(location.search);
+  const decodedCode = queryParams.get('code') ?? '';
+  const code = encodeURIComponent(decodedCode);
+
+  const { data, error } = useAxios<OauthLoginResponse>(
+    {
+      path: `/oauth/login/${provider}?code=${code}`,
+      method: 'GET',
+    },
+    true,
+  );
+  useEffect(() => {
+    if (data) {
+      localStorage.setItem('accessToken', data.accessToken);
+      localStorage.setItem('refreshToken', data.refreshToken);
+      if (!data.newAccount) {
+        navigate('/main');
+      } else {
+        navigate('/signup');
+      }
+    }
+    if (error) {
+      console.log(error);
+    }
+  }, [data]);
+
+  return (
+    <div>
+      <div>Processing...</div>
+    </div>
+  );
+};
+
+export default OauthRedirectPage;

--- a/src/pages/SigninPage.tsx
+++ b/src/pages/SigninPage.tsx
@@ -1,30 +1,51 @@
-import { MouseEventHandler } from 'react';
+import { MouseEventHandler, useEffect } from 'react';
 import TextButton from '@/components/common/TextButton';
+import AlertModal from '@/components/Modal/AlertModal';
+import { useModal } from '@/contexts/ModalProvider';
 import { useAxios } from '@/hooks/useAxios';
+
+interface OauthURLResponse {
+  url: string;
+}
 
 const SigninPage = () => {
   console.log('컴포넌트 리렌더링됨');
-  const { data, loading, error, fetchData } = useAxios({
-    path: '/oauth2/authorization/google',
+
+  const openModal = useModal();
+  const { data, error, fetchData } = useAxios<OauthURLResponse>({
     method: 'GET',
-    data: {},
   });
 
   const handleClickSocialLogin: MouseEventHandler<HTMLButtonElement> = (e) => {
     const provider = e.currentTarget.name;
     fetchData({
-      newPath: `/oauth2/authorization/${provider}`,
+      newPath: `/oauth/url/${provider}`,
     });
     console.dir(provider);
   };
 
+  useEffect(() => {
+    console.log(data?.url);
+    if (data) {
+      console.log(data.url);
+      window.open(data.url, '_self');
+    }
+    if (error) {
+      openModal(({ close }) => (
+        <AlertModal buttonClick={close} buttonText="닫기">
+          {error.message}
+        </AlertModal>
+      ));
+    }
+  }, [data, error]);
+
   return (
-    <div className="bg-gray20 flex min-h-screen flex-col items-center">
-      <div className="bg-gray10 fixed top-0 flex h-[5.8rem] w-full justify-center">
+    <div className="flex min-h-screen flex-col items-center bg-gray20">
+      <div className="fixed top-0 flex h-[5.8rem] w-full justify-center bg-gray10">
         <img src="/public/assets/logo.svg" alt="Keepy-Uppy 로고" width={70} height={41}></img>
       </div>
       <div className="mt-[18.9rem] flex w-[112rem] basis-[67.7rem] rounded-[2.4rem]  bg-white">
-        <div className="bg-gray100 w-[48rem] rounded-l-[inherit]"></div>
+        <div className="w-[48rem] rounded-l-[inherit] bg-gray100"></div>
         <div className="flex flex-grow flex-col items-center rounded-r-[inherit]">
           <div className="mt-[10.3rem] flex w-[34.2rem] flex-col items-center">
             <img src="/public/assets/logo.svg" alt="Keepy-Uppy 로고" className="h-32"></img>
@@ -32,7 +53,7 @@ const SigninPage = () => {
             <div className="flex w-full flex-col items-center gap-16">
               <div className="mt-[12rem] flex h-8 w-full items-center justify-between gap-[1.35rem]">
                 <div className="black w-full border-t-[0.1rem] border-solid border-t-[#5F5F5F4D]" />
-                <span className="text-gray100 text-nowrap text-[1.2rem] font-medium leading-8">
+                <span className="text-nowrap text-[1.2rem] font-medium leading-8 text-gray100">
                   간편 로그인
                 </span>
                 <div className="black w-full border-t-[0.1rem] border-solid border-t-[#5F5F5F4D]" />

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import CompleteStepContent from '@/components/SignupPage/CompleteStepContent';
 import EnterUserStepContent from '@/components/SignupPage/EnterUserStepContent';
 import SignupLayout from '@/components/SignupPage/SignupLayout';
@@ -6,12 +5,12 @@ import ToSStepContent from '@/components/SignupPage/ToSStepContent';
 
 const SignupPage = () => {
   return (
-    <div className="bg-gray100 flex min-h-screen flex-col items-center pt-[18.9rem]">
-      <div className="bg-gray10 fixed top-0 flex h-[5.8rem] w-full justify-center">
+    <div className="flex min-h-screen flex-col items-center bg-gray100 pt-[18.9rem]">
+      <div className="fixed top-0 flex h-[5.8rem] w-full justify-center bg-gray10">
         <img src="/public/assets/logo.svg" alt="Keepy-Uppy 로고" width={70} height={41}></img>
       </div>
       <SignupLayout>
-        <ToSStepContent />
+        <EnterUserStepContent />
       </SignupLayout>
       <footer></footer>
     </div>

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,11 @@
+export interface User {
+  id: number;
+  name: string;
+  imageUrl: string;
+  username: string;
+  oauthId: string;
+  provider: 'KAKAO' | 'GOOGLE' | 'GITHUB';
+  bio: string;
+}
+
+export type UserEditForm = Omit<User, 'id' | 'oauthId' | 'provider'>;


### PR DESCRIPTION
## 주요 구현 사항 ✨
1. useAxios 타입 수정해서 리스폰스 프로퍼티 못 잡고 린팅에러 나는 부분 해결했습니다.
2. 소셜로그인 구현했습니다. 각자 테스트 해보시면 됩니다.
3. Signup 페이지 포함 갈아엎은 부분이 많다보니까 추상화가 전혀 안되어 있습니다. 읽기 불편하시면 리팩터링 기다렸다가 해주세요... 우선 급한 구현부터 해결하겠습니다. 
4. **PR 못 쪼개서 죄송합니다** 건들게 너무 많았어요
## 스크린샷 🎨


## 구체적 구현 사항 설명 📃
```js
interface UseAxiosParams<T> {
  path?: string;
  method?: Method;
  data?: T | Record<string, never>;
}

export const useAxios = <T = unknown, P = unknown, E = unknown>(
  { path = '', method = 'GET', data = {} }: UseAxiosParams<P>,
  shouldFetch: boolean = false,
) => {
  const [state, setState] = useState<{
    loading: boolean;
    error: AxiosError<E> | null;
    data: T | null;
  }>({
```
`T` 가 `reponse data` 타입, `P`가 `requset payload` 타입입니다. `E`가 `error` 타입입니다. 혹시 문제있으면 말씀해주세요!

지금 소셜로그인까지 되는데 signin PUT 500 에러나는 상태라 signin 리다이렉트되는거 무시하고 
**담당 페이지 직접 url 쳐서 들어가셔서 테스트 해주세요.**
signin이 회원가입이라기보다 유저정보 수정이라 넘겨도 테스트하는 데는 지장 없습니다! 

## 논의사항 🤔
