### PR TITLE
Design: 자유게시판 페이지 UI 구현

### DIFF
--- a/src/components/common/BoardSection.tsx
+++ b/src/components/common/BoardSection.tsx
@@ -15,7 +15,7 @@ export default function BoardSection({ title, content }: BoardSection) {
         <ViewListIcon fill="#292929" active />
         <span>{title}</span>
       </div>
-      <div className="h-full">{content}</div>
+      <div className="h-full overflow-auto">{content}</div>
     </div>
   );
 }

--- a/src/components/posts/BulletinBoard.tsx
+++ b/src/components/posts/BulletinBoard.tsx
@@ -1,0 +1,16 @@
+import Post from '@/components/posts/Post';
+import { PostType } from '@/types/postTypes';
+
+interface BulletinBoardProps {
+  posts: PostType[];
+}
+
+export default function BulletinBoard({ posts }: BulletinBoardProps) {
+  return (
+    <div className="mt-[1.4rem] grid grid-cols-3 gap-12">
+      {posts.map((post) => {
+        return <Post post={post} />;
+      })}
+    </div>
+  );
+}

--- a/src/components/posts/Post.tsx
+++ b/src/components/posts/Post.tsx
@@ -1,0 +1,25 @@
+import { PostType } from '@/types/postTypes';
+import MeatbollsIcon from '@/assets/MeatbollsIcon';
+import ProfileIcon from '@/assets/ProfileIcon';
+
+interface PostProps {
+  post: PostType;
+}
+
+export default function Post({ post }: PostProps) {
+  const { author, content, createdDate } = post;
+
+  return (
+    <div className="relative flex h-[23.3rem] w-[49.7rem] flex-col gap-[2.4rem] rounded-[2.4rem] border border-gray30 bg-white p-[2.4rem]">
+      <MeatbollsIcon className="absolute right-[2.4rem] top-[2.4rem]" />
+      <div className="flex gap-[1.5rem]">
+        <ProfileIcon size="lg" className="row-span-2" />
+        <div className="flex flex-col gap-[0.4rem]">
+          <span className="text-body4-regular text-gray100">{author.name}</span>
+          <span className="text-body4-regular text-gray50">{createdDate}</span>
+        </div>
+      </div>
+      <span className="text-body4-regular text-gray100">{content}</span>
+    </div>
+  );
+}

--- a/src/components/posts/Post.tsx
+++ b/src/components/posts/Post.tsx
@@ -12,7 +12,7 @@ export default function Post({ post }: PostProps) {
   return (
     <div className="relative flex h-[23.3rem] w-[49.7rem] flex-col gap-[2.4rem] rounded-[2.4rem] border border-gray30 bg-white p-[2.4rem]">
       <MeatbollsIcon className="absolute right-[2.4rem] top-[2.4rem]" />
-      <div className="flex gap-[1.5rem]">
+      <div className="flex items-center gap-[1.5rem]">
         <ProfileIcon size="lg" className="row-span-2" />
         <div className="flex flex-col gap-[0.4rem]">
           <span className="text-body4-regular text-gray100">{author.name}</span>

--- a/src/mockdata/postData.ts
+++ b/src/mockdata/postData.ts
@@ -1,43 +1,213 @@
-export const teamPosts = {
-  totalPages: 0,
-  totalElements: 0,
-  size: 0,
-  content: [
-    {
-      id: 0,
-      title: 'string',
-      author: {
-        name: 'string',
-        imageUrl: 'string',
-        role: 'string',
-        grade: 'string',
+import { PostsType } from '@/types/postTypes';
+
+export const teamPosts: PostsType = {
+  posts: {
+    totalPages: 0,
+    totalElements: 12,
+    size: 12,
+    content: [
+      {
+        id: 0,
+        title: 'string',
+        author: {
+          name: '#울랄라 고릴라',
+          imageUrl: 'string',
+          role: 'string',
+          grade: 'string',
+        },
+        content:
+          '프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요. 프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.',
+        isAnnouncement: false,
+        createdDate: '2024-03-19',
+        edited: true,
       },
-      content: 'string',
-      isAnnouncement: false,
-      createdDate: '2024-03-21T14:59:57.050Z',
-      edited: true,
-    },
-  ],
-  number: 0,
-  sort: {
-    empty: true,
-    sorted: true,
-    unsorted: true,
-  },
-  numberOfElements: 0,
-  pageable: {
-    offset: 0,
+      {
+        id: 1,
+        title: 'string',
+        author: {
+          name: '#울랄라 고릴라',
+          imageUrl: 'string',
+          role: 'string',
+          grade: 'string',
+        },
+        content:
+          '프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요. 프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.',
+        isAnnouncement: false,
+        createdDate: '2024-03-19',
+        edited: true,
+      },
+      {
+        id: 2,
+        title: 'string',
+        author: {
+          name: '#울랄라 고릴라',
+          imageUrl: 'string',
+          role: 'string',
+          grade: 'string',
+        },
+        content:
+          '프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요. 프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.',
+        isAnnouncement: false,
+        createdDate: '2024-03-19',
+        edited: true,
+      },
+      {
+        id: 3,
+        title: 'string',
+        author: {
+          name: '#울랄라 고릴라',
+          imageUrl: 'string',
+          role: 'string',
+          grade: 'string',
+        },
+        content:
+          '프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요. 프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.',
+        isAnnouncement: false,
+        createdDate: '2024-03-19',
+        edited: true,
+      },
+      {
+        id: 4,
+        title: 'string',
+        author: {
+          name: '#울랄라 고릴라',
+          imageUrl: 'string',
+          role: 'string',
+          grade: 'string',
+        },
+        content:
+          '프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요. 프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.',
+        isAnnouncement: false,
+        createdDate: '2024-03-19',
+        edited: true,
+      },
+      {
+        id: 5,
+        title: 'string',
+        author: {
+          name: '#울랄라 고릴라',
+          imageUrl: 'string',
+          role: 'string',
+          grade: 'string',
+        },
+        content:
+          '프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요. 프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.',
+        isAnnouncement: false,
+        createdDate: '2024-03-19',
+        edited: true,
+      },
+      {
+        id: 6,
+        title: 'string',
+        author: {
+          name: '#울랄라 고릴라',
+          imageUrl: 'string',
+          role: 'string',
+          grade: 'string',
+        },
+        content:
+          '프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요. 프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.',
+        isAnnouncement: false,
+        createdDate: '2024-03-19',
+        edited: true,
+      },
+      {
+        id: 7,
+        title: 'string',
+        author: {
+          name: '#울랄라 고릴라',
+          imageUrl: 'string',
+          role: 'string',
+          grade: 'string',
+        },
+        content:
+          '프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요. 프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.',
+        isAnnouncement: false,
+        createdDate: '2024-03-19',
+        edited: true,
+      },
+      {
+        id: 8,
+        title: 'string',
+        author: {
+          name: '#울랄라 고릴라',
+          imageUrl: 'string',
+          role: 'string',
+          grade: 'string',
+        },
+        content:
+          '프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요. 프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.',
+        isAnnouncement: false,
+        createdDate: '2024-03-19',
+        edited: true,
+      },
+      {
+        id: 9,
+        title: 'string',
+        author: {
+          name: '#울랄라 고릴라',
+          imageUrl: 'string',
+          role: 'string',
+          grade: 'string',
+        },
+        content:
+          '프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요. 프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.',
+        isAnnouncement: false,
+        createdDate: '2024-03-19',
+        edited: true,
+      },
+      {
+        id: 10,
+        title: 'string',
+        author: {
+          name: '#울랄라 고릴라',
+          imageUrl: 'string',
+          role: 'string',
+          grade: 'string',
+        },
+        content:
+          '프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요. 프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.',
+        isAnnouncement: false,
+        createdDate: '2024-03-19',
+        edited: true,
+      },
+      {
+        id: 11,
+        title: 'string',
+        author: {
+          name: '#울랄라 고릴라',
+          imageUrl: 'string',
+          role: 'string',
+          grade: 'string',
+        },
+        content:
+          '프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요. 프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.',
+        isAnnouncement: false,
+        createdDate: '2024-03-19',
+        edited: true,
+      },
+    ],
+    number: 12,
     sort: {
       empty: true,
       sorted: true,
       unsorted: true,
     },
-    pageNumber: 0,
-    pageSize: 0,
-    paged: true,
-    unpaged: true,
+    numberOfElements: 0,
+    pageable: {
+      offset: 0,
+      sort: {
+        empty: true,
+        sorted: true,
+        unsorted: true,
+      },
+      pageNumber: 0,
+      pageSize: 0,
+      paged: true,
+      unpaged: true,
+    },
+    first: true,
+    last: true,
+    empty: true,
   },
-  first: true,
-  last: true,
-  empty: true,
 };

--- a/src/mockdata/postData.ts
+++ b/src/mockdata/postData.ts
@@ -1,0 +1,43 @@
+export const teamPosts = {
+  totalPages: 0,
+  totalElements: 0,
+  size: 0,
+  content: [
+    {
+      id: 0,
+      title: 'string',
+      author: {
+        name: 'string',
+        imageUrl: 'string',
+        role: 'string',
+        grade: 'string',
+      },
+      content: 'string',
+      isAnnouncement: false,
+      createdDate: '2024-03-21T14:59:57.050Z',
+      edited: true,
+    },
+  ],
+  number: 0,
+  sort: {
+    empty: true,
+    sorted: true,
+    unsorted: true,
+  },
+  numberOfElements: 0,
+  pageable: {
+    offset: 0,
+    sort: {
+      empty: true,
+      sorted: true,
+      unsorted: true,
+    },
+    pageNumber: 0,
+    pageSize: 0,
+    paged: true,
+    unpaged: true,
+  },
+  first: true,
+  last: true,
+  empty: true,
+};

--- a/src/pages/TeamsPostsPage.tsx
+++ b/src/pages/TeamsPostsPage.tsx
@@ -1,7 +1,30 @@
+import BoardSection from '@/components/common/BoardSection';
 import PageLayout from '@/components/common/PageLayout';
+import Post from '@/components/posts/Post';
+import { PostType } from '@/types/postTypes';
+
+const post: PostType = {
+  id: 0,
+  title: 'string',
+  author: {
+    name: '#울랄라 고릴라',
+    imageUrl: 'string',
+    role: 'string',
+    grade: 'string',
+  },
+  content:
+    '프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요. 프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.',
+  isAnnouncement: false,
+  createdDate: '2024-03-19',
+  edited: true,
+};
 
 const TeamsPostsPage = () => {
-  return <PageLayout>{}</PageLayout>;
+  return (
+    <PageLayout>
+      <BoardSection title="Bulletin Board" content={<Post post={post} />} />
+    </PageLayout>
+  );
 };
 
 export default TeamsPostsPage;

--- a/src/pages/TeamsPostsPage.tsx
+++ b/src/pages/TeamsPostsPage.tsx
@@ -1,28 +1,15 @@
+import { teamPosts } from '@/mockdata/postData';
 import BoardSection from '@/components/common/BoardSection';
 import PageLayout from '@/components/common/PageLayout';
-import Post from '@/components/posts/Post';
-import { PostType } from '@/types/postTypes';
-
-const post: PostType = {
-  id: 0,
-  title: 'string',
-  author: {
-    name: '#울랄라 고릴라',
-    imageUrl: 'string',
-    role: 'string',
-    grade: 'string',
-  },
-  content:
-    '프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요. 프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.프로젝트 시작전에 간단한 자기 소개부터 하려고 합니다. 장기자랑 준비해 오세요.',
-  isAnnouncement: false,
-  createdDate: '2024-03-19',
-  edited: true,
-};
+import BulletinBoard from '@/components/posts/BulletinBoard';
 
 const TeamsPostsPage = () => {
   return (
     <PageLayout>
-      <BoardSection title="Bulletin Board" content={<Post post={post} />} />
+      <BoardSection
+        title="Bulletin Board"
+        content={<BulletinBoard posts={teamPosts.posts.content} />}
+      />
     </PageLayout>
   );
 };

--- a/src/types/postTypes.ts
+++ b/src/types/postTypes.ts
@@ -1,0 +1,14 @@
+export interface PostType {
+  id: number;
+  title: string;
+  author: {
+    name: string;
+    imageUrl: string;
+    role: string;
+    grade: string;
+  };
+  content: string;
+  isAnnouncement: boolean;
+  createdDate: string;
+  edited: boolean;
+}

--- a/src/types/postTypes.ts
+++ b/src/types/postTypes.ts
@@ -12,3 +12,34 @@ export interface PostType {
   createdDate: string;
   edited: boolean;
 }
+
+export interface PostsType {
+  posts: {
+    totalPages: number;
+    totalElements: number;
+    size: number;
+    content: PostType[];
+    number: number;
+    sort: {
+      empty: boolean;
+      sorted: boolean;
+      unsorted: boolean;
+    };
+    numberOfElements: number;
+    pageable: {
+      offset: number;
+      sort: {
+        empty: boolean;
+        sorted: boolean;
+        unsorted: boolean;
+      };
+      pageNumber: number;
+      pageSize: number;
+      paged: boolean;
+      unpaged: boolean;
+    };
+    first: boolean;
+    last: boolean;
+    empty: boolean;
+  };
+}


### PR DESCRIPTION
## 주요 구현 사항 ✨
- 자유게시판 페이지 UI 구현

## 스크린샷 🎨
![Screenshot 2024-03-22 at 12 43 27 AM](https://github.com/codeit-part4-8team-project/main/assets/148641571/682a27d6-c815-430b-8848-b78cc9a28c93)

## 구체적 구현 사항 설명 📃
- api 연동은 아직이고 목데이터 만들어 작업했습니다.

## 논의사항 🤔
- 댓글이랑 고정 기능은 회의 때 일단 없는 걸로 얘기 된 부분이라 ui에 넣진 않았습니다. 나중에 디자인 수정되면 고치겠습니다.
