### PR TITLE
Fix: 나의 캘린더, 팀 캘린더 페이지 데이터 연동

### DIFF
--- a/src/components/SchedulesPage/ControlDate.tsx
+++ b/src/components/SchedulesPage/ControlDate.tsx
@@ -8,6 +8,7 @@ import { calendarContext } from '@/contexts/CalenarProvider';
 
 interface ControlDateProp {
   mode: 'month' | 'week' | 'modal';
+  className?: string;
 }
 function ControlDate({ mode }: ControlDateProp) {
   const Container = clsx('w-full', 'flex', 'items-center');

--- a/src/components/SchedulesPage/GroupFilter.tsx
+++ b/src/components/SchedulesPage/GroupFilter.tsx
@@ -4,13 +4,14 @@ import FilterCheckIconLight from '@/assets/FilterCheckIconLight';
 
 interface ChecklistItemProps {
   isChecked: boolean;
-  title: string;
-  color?: string;
+  item: Item; // 수정된 부분
   onCheck: (title: string, isChecked: boolean) => void;
 }
 
-function ChecklistItem({ title, color, isChecked, onCheck }: ChecklistItemProps) {
+function ChecklistItem({ item, isChecked, onCheck }: ChecklistItemProps) {
+  const { title, teamResponse } = item; // 수정된 부분
   const nameStyle = 'text-body4-bold ml-4 text-[#292929]';
+  const color = teamResponse ? teamResponse.color : ''; // 수정된 부분
   return (
     <div className="mr-[7.4rem] flex w-[17.3rem] items-center justify-between">
       <div className="flex">
@@ -29,39 +30,57 @@ function ChecklistItem({ title, color, isChecked, onCheck }: ChecklistItemProps)
 }
 
 export interface Item {
+  id: number;
   title: string;
-  color?: string;
+  content: string;
+  startDateTime: string;
+  endDateTime: string;
+  author?: {
+    name: string;
+    imageUrl: string;
+    role: string;
+    grade: string;
+    username: string;
+    createdDate: string;
+  };
+  teamResponse?: {
+    id: number;
+    name: string;
+    description: string;
+    color: string;
+  };
 }
-
 interface GroupFilterProps {
   items: Item[];
-  onCheck: (checkedItem: string[]) => void;
+  onCheck: (checkedItems: Item[]) => void;
   className?: string;
 }
 
 function GroupFilter({ items, onCheck, className }: GroupFilterProps) {
-  const [checkedItems, setCheckedItems] = useState<string[]>([]);
+  const [checkedItems, setCheckedItems] = useState<Item[]>([]);
 
   const handleCheck = (title: string, isChecked: boolean) => {
     const updatedCheckedItems = isChecked
-      ? [...checkedItems, title]
-      : checkedItems.filter((item) => item !== title);
-    setCheckedItems(updatedCheckedItems);
-    onCheck(updatedCheckedItems);
+      ? [...checkedItems, items.find((item) => item.title === title)!]
+      : checkedItems.filter((item) => item.title !== title);
+    setCheckedItems(updatedCheckedItems as Item[]);
+    onCheck(updatedCheckedItems as Item[]);
   };
 
   return (
     <div className={`flex flex-col ${className}`}>
       <div className="mb-14 text-body3-bold text-[#A1A1A1]">그룹 필터</div>
-      {items.map((item, index) => (
-        <ChecklistItem
-          key={index}
-          name={item.name}
-          color={item.color}
-          isChecked={checkedItems[index]}
-          onCheck={() => handleCheck(index)}
-        />
-      ))}
+      {items &&
+        items.map((item, index) => (
+          <ChecklistItem
+            key={index}
+            item={item} // 수정된 부분
+            isChecked={checkedItems.some(
+              (checkedItem) => checkedItem.title === item.title, // 수정된 부분
+            )}
+            onCheck={(title: string, isChecked: boolean) => handleCheck(title, isChecked)}
+          />
+        ))}
     </div>
   );
 }

--- a/src/components/SchedulesPage/Schedules.tsx
+++ b/src/components/SchedulesPage/Schedules.tsx
@@ -2,33 +2,22 @@ import { useContext, useEffect, useRef, useState } from 'react';
 import clsx from 'clsx';
 import ScheduleModal from '../Modal/ScheduleModal';
 import TextButton from '../common/TextButton';
-import ControlDate from './ControlDate';
 import DateBox from './DateBox';
 import { Item } from './GroupFilter';
 import GroupFilter from './GroupFilter';
 import { calendarContext } from '@/contexts/CalenarProvider';
 import { defaultInstance } from '@/hooks/useAxios';
-import CalendarIcon from '@/assets/CalendarIcon';
 
 interface SchedulesProps {
-  calendarType: string;
+  calendarType: '나의 캘린더' | '팀 캘린더';
 }
-export interface SchedulesData {
-  title: string;
-  content: string;
-  startDateTime: string;
-  endDateTime: string;
-  date: Date;
-}
-
 function Schedules({ calendarType }: SchedulesProps) {
   const { schedules, setSchedules, setFilteredSchedules } = useContext(calendarContext);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const modalRef = useRef<HTMLDivElement>(null);
   const [groupData, setGroupData] = useState<Item[]>([]);
 
-  const container =
-    'w-[161.2rem] bg-gray10 mt-[8.6rem] ml-[28.4rem] mb-[2.4rem]  mr-[2.4rem] pb-[3rem] pt-12 pl-12 pr-[26.9rem] rounded-[2.4rem]';
+  const container = 'w-[161.2rem] bg-gray10 mb-[2.4rem] mr-[2.4rem] pr-[26.9rem] rounded-[2.4rem]';
 
   const title = clsx('flex items-center ');
 
@@ -44,45 +33,37 @@ function Schedules({ calendarType }: SchedulesProps) {
     setIsModalOpen(false);
   };
 
-  let calendarsType = calendarType === '나의 캘린더' ? 'My Calendar' : 'Team Calendar ';
-
   useEffect(() => {
-    // calendarType에 따라 다른 엔드포인트를 호출하여 데이터를 가져옴
-    const fetchData = async () => {
-      try {
-        let endpoint = '';
-        if (calendarType === '나의 캘린더') {
-          endpoint = `http://ec2-43-203-69-64.ap-northeast-2.compute.amazonaws.com:8080/api/schedule/user/month/5?localDateTime=2024-03-20%2011%3A11%3A11`;
-        } else {
-          endpoint = '/public/data/GroupFilterTeam.json';
-        }
-
-        if (groupData.length === 0) {
+    // calendarType가 '나의 캘린더'인 경우에만 데이터를 가져옴
+    if (calendarType === '나의 캘린더') {
+      const fetchData = async () => {
+        try {
+          const endpoint = `http://ec2-43-203-69-64.ap-northeast-2.compute.amazonaws.com:8080/api/schedule/user/month?showUser=true&localDate=2023-03-20`;
           const response = await defaultInstance.get(endpoint);
-          setGroupData(response.data);
+          setSchedules(response.data.userSchedulesResponse);
+          setGroupData(response.data.userSchedulesResponse);
+        } catch (error) {
+          console.error('Error fetching group filter data:', error);
         }
-      } catch (error) {
-        console.error('Error fetching group filter data:', error);
-      }
-    };
+      };
 
-    fetchData();
+      fetchData();
+    }
   }, [calendarType]);
-
   useEffect(() => {
     const fetchSchedule = async () => {
       try {
         let endpoint = '';
         if (calendarType === '나의 캘린더') {
-          endpoint =
-            'http://ec2-43-203-69-64.ap-northeast-2.compute.amazonaws.com:8080/api/schedule/user/month/5?localDateTime=2024-03-20%2011%3A11%3A11';
-        } else {
-          endpoint = '/public/data/TeamSchedule.json';
+          endpoint = `http://ec2-43-203-69-64.ap-northeast-2.compute.amazonaws.com:8080/api/schedule/user/month?showUser=true&localDate=2023-03-20`;
+        } else if (calendarType === '팀 캘린더') {
+          endpoint = `http://ec2-43-203-69-64.ap-northeast-2.compute.amazonaws.com:8080/api/schedule/team/month/5?localDate=2024-03-07`; // 변경된 부분: 팀 캘린더용 엔드포인트로 변경
         }
 
-        if (!schedules || schedules.length === 0) {
-          const response = await defaultInstance.get(endpoint);
-          setSchedules(response.data);
+        const response = await defaultInstance.get(endpoint);
+        if (calendarType === '팀 캘린더') {
+          setSchedules(response.data); // 변경된 부분
+          setFilteredSchedules(response.data.teamSchedules);
         }
       } catch (error) {
         console.error('Error fetching group filter data:', error);
@@ -90,32 +71,30 @@ function Schedules({ calendarType }: SchedulesProps) {
     };
 
     fetchSchedule();
-  }, [calendarType]); // schedules 상태 추가
+  }, [calendarType]);
 
-  const handleCheck = (checkedItems: string[]) => {
-    setFilteredSchedules(
-      schedules ? schedules.filter((schedule) => checkedItems.includes(schedule.title)) : [],
-    );
+  const handleCheck = (checkedItems: Item[]) => {
+    // 체크된 아이템들을 기반으로 스케줄 필터링 수행
+    const checkedItemTitles = checkedItems.map((item) => item.title);
+    const filteredSchedules =
+      schedules?.filter((schedule) => checkedItemTitles.includes(schedule.title)) ?? [];
+    setFilteredSchedules(filteredSchedules);
   };
 
   return (
     <div className={container}>
       <div className="m-0 flex items-center justify-between p-0 ">
-        <div className={title}>
-          <CalendarIcon active={true} className="mr-4 h-[3.6rem] w-[3.6rem]"></CalendarIcon>
-          <span className="mr-[10rem] whitespace-nowrap font-rammetto text-body1-medium">
-            {calendarsType}
-          </span>
-          <ControlDate mode="month" />
-        </div>
+        <div className={title}></div>
 
         <TextButton buttonSize="sm" color="black">
           일정생성
         </TextButton>
         {isModalOpen && <ScheduleModal />}
       </div>
-      <div className="mr-[0.1rem] mt-[3.9rem] flex gap-12">
-        <GroupFilter items={groupData} onCheck={handleCheck} />
+      <div className="mr-[0.1rem] mt-[1.7rem] flex gap-12">
+        {calendarType === '나의 캘린더' && (
+          <GroupFilter className="w-[16.5rem]" items={groupData} onCheck={handleCheck} />
+        )}
         <DateBox mode="month" />
       </div>
     </div>

--- a/src/components/common/BoardSection.tsx
+++ b/src/components/common/BoardSection.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import ControlDate from '../SchedulesPage/ControlDate';
 import CalendarIcon from '@/assets/CalendarIcon';
 import FolderIcon from '@/assets/FolderIcon';
 import MegaphoneIcon from '@/assets/MegaphoneIcon';
@@ -20,11 +21,16 @@ const ICON = {
 };
 
 export default function BoardSection({ title, content }: BoardSection) {
+  const shouldDisplayControlDate = title === 'My calendar' || title === 'Team calendar';
+  const controlDateMargin = title === 'My calendar' ? 'mr-[6.8rem]' : 'ml-[6.8rem] ';
   return (
     <div className="flex h-full flex-col gap-[1.6rem]">
-      <div className="flex items-center gap-[0.9rem] font-rammetto text-body1-regular tracking-[-0.036rem] text-gray100">
+      <div className="flex items-center gap-[0.9rem] whitespace-nowrap text-body1-regular tracking-[-0.036rem] text-gray100">
         {ICON[title]}
-        <span>{title}</span>
+        <span className={`font-rammetto ${controlDateMargin}`}>{title}</span>
+        {shouldDisplayControlDate && (
+          <ControlDate className={`text-body4-bold text-gray100`} mode="month" />
+        )}
       </div>
       <div className="h-full overflow-auto">{content}</div>
     </div>

--- a/src/contexts/CalenarProvider.tsx
+++ b/src/contexts/CalenarProvider.tsx
@@ -1,19 +1,44 @@
 import React, { createContext, useState } from 'react';
-import { SchedulesData } from '@/components/SchedulesPage/Schedules';
 
+//import { SchedulesData } from '@/components/SchedulesPage/Schedules';
+
+export interface SchedulesData {
+  id: number;
+  title: string;
+  content: string;
+  startDateTime: string;
+  endDateTime: string;
+  author?: {
+    name: string;
+    imageUrl: string;
+    role: string;
+    grade: string;
+    username: string;
+    createdDate: string;
+  };
+  teamResponse?: {
+    id: number;
+    name: string;
+    description: string;
+    color: string;
+  };
+}
 export interface CalendarContextType {
   nowDate: Date;
-  mode: string; // mode 속성 추가
+  mode: string;
   setNowDate: React.Dispatch<React.SetStateAction<Date>>;
   schedules?: SchedulesData[];
   setSchedules: React.Dispatch<React.SetStateAction<SchedulesData[]>>;
   filteredSchedules?: SchedulesData[];
   setFilteredSchedules: React.Dispatch<React.SetStateAction<SchedulesData[]>>;
+  calendarType?: string;
 }
 
 const defaultContextValue: CalendarContextType = {
   nowDate: new Date(),
   mode: 'month',
+  calendarType: '나의 캘린더',
+  schedules: [],
   setNowDate: () => {},
   setSchedules: () => [], // 스케줄 변경 함수를 빈 함수로 초기화
   filteredSchedules: [],
@@ -27,10 +52,11 @@ export const CalendarProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   const [mode, setMode] = useState('month'); // mode 상태 추가
   const [schedules, setSchedules] = useState<SchedulesData[]>([]);
   const [filteredSchedules, setFilteredSchedules] = useState<SchedulesData[]>([]);
-
+  const [calendarType, setCalendarType] = useState('나의 캘린더');
   const contextValue: CalendarContextType = {
     nowDate,
     mode,
+    calendarType,
     setNowDate,
     schedules,
     setSchedules,

--- a/src/pages/TeamSchedulesPage.tsx
+++ b/src/pages/TeamSchedulesPage.tsx
@@ -1,17 +1,20 @@
 import clsx from 'clsx';
+import BoardSection from '@/components/common/BoardSection';
 import Nav from '@/components/common/Nav';
 import SideBar from '@/components/common/sideBar/SideBar';
 import Schedules from '@/components/SchedulesPage/Schedules';
 
 const TeamSchedulesPage = () => {
   return (
-    <div className="bg-[ #EFEFEF] w-[192rem]">
-      <Nav />
-      <div className={clsx('flex')}>
-        <SideBar />
-        <Schedules calendarType="팀 캘린더 " />
-      </div>
-    </div>
+    // <div className="bg-[ #EFEFEF] w-[192rem]">
+    //   <Nav />
+    //   <div className={clsx('flex')}>
+    //     <SideBar />
+    //     <Schedules calendarType="팀 캘린더" />
+    //   </div>
+    // </div>
+
+    <BoardSection title="Team calendar" content={<Schedules calendarType="팀 캘린더" />} />
   );
 };
 

--- a/src/pages/team/TeamCalendar.tsx
+++ b/src/pages/team/TeamCalendar.tsx
@@ -1,9 +1,6 @@
-import SchedulesPage from '@/pages/SchedulesPage';
+import BoardSection from '@/components/common/BoardSection';
+import Schedules from '@/components/SchedulesPage/Schedules';
 
 export default function TeamCalendar() {
-  return (
-    <div>
-      <SchedulesPage />
-    </div>
-  );
+  return <BoardSection title="Team calendar" content={<Schedules calendarType="팀 캘린더" />} />;
 }


### PR DESCRIPTION
## 주요 구현 사항 ✨

-나의 캘린더 필터 기능에 맞춰 데이터 넣기 빼기 가능 
-팀 캘린더 캘린더 안에 데이터 불러오기 성공

## 스크린샷 🎨

-
![image](https://github.com/codeit-part4-8team-project/main/assets/145126857/7fcb5cf0-6145-48e3-bc6d-f9fb56391b24)


## 구체적 구현 사항 설명 📃

-

## 논의사항 🤔

-문제점이 컬러가 반영이 안되고 있어서 이부분 계속 수정해야 할 것 같습니다. ..
-캘린더 타입을 CalendrProvider파일에 합쳐 놓았는데 이렇게 하는 게 잘 한건가요? 데이터는 잘 불러져 옵니다 (유저아이디로 데이터 불러오기, 팀 아이디로 데이터 불러오기 데이터 구조를 합친 것 입니다!)
-혹시 이외의 수정사항이 있다면 말씀해 주세요 .. ㅎ