### PR TITLE
Feat: 페이지네이션 구현

### DIFF
--- a/src/assets/PageArrowLeftIcon.tsx
+++ b/src/assets/PageArrowLeftIcon.tsx
@@ -1,0 +1,19 @@
+import { IconProps } from '@/types/iconProps';
+
+function PageArrowLeftIcon({ fill, className, ...props }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+      {...props}
+    >
+      <path d="M14.25 7.25L9.75 12.25L14.25 17.25" stroke={fill || '#5E5955'} strokeWidth="1.1" />
+    </svg>
+  );
+}
+
+export default PageArrowLeftIcon;

--- a/src/assets/PageArrowRightIcon.tsx
+++ b/src/assets/PageArrowRightIcon.tsx
@@ -1,0 +1,19 @@
+import { IconProps } from '@/types/iconProps';
+
+function PageArrowRightIcon({ fill, className, ...props }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+      {...props}
+    >
+      <path d="M9.75 17.25L14.25 12.25L9.75 7.25" stroke={fill || '#5E5955'} strokeWidth="1.1" />
+    </svg>
+  );
+}
+
+export default PageArrowRightIcon;

--- a/src/components/Post/PostList.tsx
+++ b/src/components/Post/PostList.tsx
@@ -8,18 +8,18 @@ interface PostListProps {
 
 export default function PostList({ posts }: PostListProps) {
   return (
-    <li className="mt-[1.4rem] grid w-fit grid-cols-2 gap-12">
+    <ul className="mt-[1.4rem] grid w-fit grid-cols-2 gap-12">
       {posts.length !== 0 ? (
         posts.map((post) => {
           return (
-            <ul key={post.id}>
+            <li key={post.id}>
               <PostItem post={post} />
-            </ul>
+            </li>
           );
         })
       ) : (
         <NoCard backgroundColor="bg-white">게시글이 없습니다.</NoCard>
       )}
-    </li>
+    </ul>
   );
 }

--- a/src/components/announcement/AnnouncementPageList.tsx
+++ b/src/components/announcement/AnnouncementPageList.tsx
@@ -2,16 +2,14 @@ import { useParams } from 'react-router-dom';
 import NoCard from '@/components/common/NoCard';
 import AnnouncementItem from '@/components/announcement/AnnouncementItem';
 import { useTeam } from '@/contexts/TeamProvider';
-import { Announcements } from '@/types/announcementTypes';
+import { Announcement } from '@/types/announcementTypes';
 
 interface AnnouncementPageListProps {
-  announcements: Announcements;
+  announcements: Announcement[] | [];
 }
 
 /* 팀의 공지사항 페이지에서 사용하는 공지글 리스트 */
-export default function AnnouncementPageList({
-  announcements: { content },
-}: AnnouncementPageListProps) {
+export default function AnnouncementPageList({ announcements }: AnnouncementPageListProps) {
   const { teamId } = useParams();
 
   if (!teamId) throw Error('해당 팀 ID가 존재하지 않습니다.');
@@ -20,9 +18,9 @@ export default function AnnouncementPageList({
 
   return (
     <div className="w-[132.6rem]">
-      {content.length !== 0 ? (
+      {announcements.length !== 0 ? (
         <ul className="grid w-fit list-none grid-cols-3 gap-[2.4rem]">
-          {content.map((announcement) => {
+          {announcements.map((announcement) => {
             return (
               <li key={announcement.id}>
                 <AnnouncementItem announcement={announcement} team={team} />

--- a/src/components/common/BoardSection.tsx
+++ b/src/components/common/BoardSection.tsx
@@ -7,7 +7,8 @@ import ViewListIcon from '@/assets/ViewListIcon';
 
 interface BoardSection {
   title: keyof typeof ICON;
-  content: ReactNode;
+  content?: ReactNode;
+  children?: ReactNode;
 }
 
 const ICON = {
@@ -20,7 +21,7 @@ const ICON = {
   콘텐츠: <FolderIcon fill="#292929" active />,
 };
 
-export default function BoardSection({ title, content }: BoardSection) {
+export default function BoardSection({ title, content, children }: BoardSection) {
   const shouldDisplayControlDate = title === 'My calendar' || title === 'Team calendar';
   const controlDateMargin = title === 'My calendar' ? 'mr-[6.8rem]' : 'ml-[6.8rem] ';
   return (
@@ -32,7 +33,8 @@ export default function BoardSection({ title, content }: BoardSection) {
           <ControlDate className={`text-body4-bold text-gray100`} mode="month" />
         )}
       </div>
-      <div className="h-full overflow-auto">{content}</div>
+      <div className="h-full overflow-auto">{content || children}</div>{' '}
+      {/* content안에 단일 컴포넌트로 넣기 불편한 페이지가 있어서 chilren으로 받을 수 있도록 했습니다.*/}
     </div>
   );
 }

--- a/src/components/common/pagenation/PageNumber.tsx
+++ b/src/components/common/pagenation/PageNumber.tsx
@@ -1,0 +1,19 @@
+import clsx from 'clsx';
+
+interface PageNumberProps {
+  isCurrent: boolean;
+  children: number;
+  onClick: (page: number) => void;
+}
+
+export default function PageNumber({ isCurrent, children, onClick }: PageNumberProps) {
+  const handleClick = () => onClick(children);
+  return (
+    <button
+      onClick={handleClick}
+      className={clsx('text-body2-bold', isCurrent ? 'text-[#6F6963]' : 'text-[#C0BCB6]')}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/common/pagenation/PageNumber.tsx
+++ b/src/components/common/pagenation/PageNumber.tsx
@@ -1,13 +1,15 @@
 import clsx from 'clsx';
+import { usePagenation } from '@/contexts/PageProvider';
 
 interface PageNumberProps {
   isCurrent: boolean;
   children: number;
-  onClick: (page: number) => void;
 }
 
-export default function PageNumber({ isCurrent, children, onClick }: PageNumberProps) {
-  const handleClick = () => onClick(children);
+export default function PageNumber({ isCurrent, children }: PageNumberProps) {
+  const { setCurrentPage } = usePagenation();
+  const handleClick = () => setCurrentPage(children);
+
   return (
     <button
       onClick={handleClick}

--- a/src/components/common/pagenation/Pagenation.tsx
+++ b/src/components/common/pagenation/Pagenation.tsx
@@ -3,22 +3,30 @@ import PageArrowLeftIcon from '@/assets/PageArrowLeftIcon';
 import PageArrowRightIcon from '@/assets/PageArrowRightIcon';
 
 interface PagenationProps {
+  totalPages: number;
   currentPage: number;
   setCurrentPage: (page: number) => void;
 }
 
-const PAGE_NUMS = [1, 2, 3];
+const createNumArray = (num: number) => {
+  const newArray = Array.from({ length: num }, (_, idx) => idx + 1);
+  return newArray;
+};
 
-export default function Pagenation({ currentPage, setCurrentPage }: PagenationProps) {
+export default function Pagenation({ totalPages, currentPage, setCurrentPage }: PagenationProps) {
+  const pageNums = createNumArray(totalPages);
+
   const handlePageNumberClick = (page: number) => {
     setCurrentPage(page);
   };
 
   return (
     <div className="flex gap-[2.4rem]">
-      <PageArrowLeftIcon />
+      <button type="button">
+        <PageArrowLeftIcon />
+      </button>
       <ul className="flex gap-[2.4rem]">
-        {PAGE_NUMS.map((page) => {
+        {pageNums.map((page) => {
           return (
             <li key={page}>
               <PageNumber isCurrent={currentPage === page} onClick={handlePageNumberClick}>
@@ -28,7 +36,9 @@ export default function Pagenation({ currentPage, setCurrentPage }: PagenationPr
           );
         })}
       </ul>
-      <PageArrowRightIcon />
+      <button type="button">
+        <PageArrowRightIcon />
+      </button>
     </div>
   );
 }

--- a/src/components/common/pagenation/Pagenation.tsx
+++ b/src/components/common/pagenation/Pagenation.tsx
@@ -1,0 +1,25 @@
+import PageNumber from '@/components/common/pagenation/PageNumber';
+import PageArrowLeftIcon from '@/assets/PageArrowLeftIcon';
+import PageArrowRightIcon from '@/assets/PageArrowRightIcon';
+
+interface PagenationProps {
+  currentPage: number;
+}
+
+export default function Pagenation({ currentPage }: PagenationProps) {
+  return (
+    <div className="flex gap-[2.4rem]">
+      <PageArrowLeftIcon />
+      <PageNumber isCurrent={true}>{1}</PageNumber>
+      <PageNumber isCurrent={false}>{2}</PageNumber>
+      <PageNumber isCurrent={false}>{3}</PageNumber>
+      <PageNumber isCurrent={false}>{4}</PageNumber>
+      <PageNumber isCurrent={false}>{5}</PageNumber>
+      <PageNumber isCurrent={false}>{6}</PageNumber>
+      <PageNumber isCurrent={false}>{7}</PageNumber>
+      <PageNumber isCurrent={false}>{8}</PageNumber>
+      <PageNumber isCurrent={false}>{9}</PageNumber>
+      <PageArrowRightIcon />
+    </div>
+  );
+}

--- a/src/components/common/pagenation/Pagenation.tsx
+++ b/src/components/common/pagenation/Pagenation.tsx
@@ -1,46 +1,11 @@
-import { useState } from 'react';
 import PageNumber from '@/components/common/pagenation/PageNumber';
+import { usePagenation } from '@/contexts/PageProvider';
 import PageArrowLeftIcon from '@/assets/PageArrowLeftIcon';
 import PageArrowRightIcon from '@/assets/PageArrowRightIcon';
 
-interface PagenationProps {
-  totalPages: number;
-  currentPage: number;
-  setCurrentPage: (page: number) => void;
-}
-
-/* 예시: createNumArray(3, 5)는 [3, 4, 5, 6, 7] 배열을 반환 */
-const createNumArray = (start: number, size: number) => {
-  const newArray = Array.from({ length: size }, (_, idx) => start + idx);
-  return newArray;
-};
-
-const SIZE = 10; // 한 번에 몇 개의 페이지를 보여줄지
-
-export default function Pagenation({ totalPages, currentPage, setCurrentPage }: PagenationProps) {
-  const [startPage, setStartPage] = useState(1);
-  let pageNums = createNumArray(startPage, SIZE);
-
-  const isFirst = startPage === 1;
-  const isLast = pageNums.includes(totalPages);
-  const isLastFull = totalPages % SIZE === 0; // 총 페이지 수와 페이지네이션 사이즈가 맞아 떨어지는 경우
-
-  if (isLast && !isLastFull) {
-    const pageNeeded = isFirst ? totalPages % SIZE : totalPages % (startPage - 1);
-    pageNums = pageNums.slice(0, pageNeeded);
-  }
-
-  const handlePageNumberClick = (page: number) => {
-    setCurrentPage(page);
-  };
-
-  const handleNextClick = () => {
-    setStartPage(startPage + SIZE);
-  };
-
-  const handlePrevClick = () => {
-    setStartPage(startPage - SIZE);
-  };
+export default function Pagenation() {
+  const { pageNumsArray, currentPage, isFirst, isLast, handlePrevClick, handleNextClick } =
+    usePagenation();
 
   return (
     <div className="flex gap-[2.4rem]">
@@ -48,12 +13,10 @@ export default function Pagenation({ totalPages, currentPage, setCurrentPage }: 
         <PageArrowLeftIcon />
       </button>
       <ul className="flex gap-[2.4rem]">
-        {pageNums.map((page) => {
+        {pageNumsArray.map((page) => {
           return (
             <li key={page}>
-              <PageNumber isCurrent={currentPage === page} onClick={handlePageNumberClick}>
-                {page}
-              </PageNumber>
+              <PageNumber isCurrent={currentPage === page}>{page}</PageNumber>
             </li>
           );
         })}

--- a/src/components/common/pagenation/Pagenation.tsx
+++ b/src/components/common/pagenation/Pagenation.tsx
@@ -4,21 +4,30 @@ import PageArrowRightIcon from '@/assets/PageArrowRightIcon';
 
 interface PagenationProps {
   currentPage: number;
+  setCurrentPage: (page: number) => void;
 }
 
-export default function Pagenation({ currentPage }: PagenationProps) {
+const PAGE_NUMS = [1, 2, 3];
+
+export default function Pagenation({ currentPage, setCurrentPage }: PagenationProps) {
+  const handlePageNumberClick = (page: number) => {
+    setCurrentPage(page);
+  };
+
   return (
     <div className="flex gap-[2.4rem]">
       <PageArrowLeftIcon />
-      <PageNumber isCurrent={true}>{1}</PageNumber>
-      <PageNumber isCurrent={false}>{2}</PageNumber>
-      <PageNumber isCurrent={false}>{3}</PageNumber>
-      <PageNumber isCurrent={false}>{4}</PageNumber>
-      <PageNumber isCurrent={false}>{5}</PageNumber>
-      <PageNumber isCurrent={false}>{6}</PageNumber>
-      <PageNumber isCurrent={false}>{7}</PageNumber>
-      <PageNumber isCurrent={false}>{8}</PageNumber>
-      <PageNumber isCurrent={false}>{9}</PageNumber>
+      <ul className="flex gap-[2.4rem]">
+        {PAGE_NUMS.map((page) => {
+          return (
+            <li key={page}>
+              <PageNumber isCurrent={currentPage === page} onClick={handlePageNumberClick}>
+                {page}
+              </PageNumber>
+            </li>
+          );
+        })}
+      </ul>
       <PageArrowRightIcon />
     </div>
   );

--- a/src/components/common/pagenation/Pagenation.tsx
+++ b/src/components/common/pagenation/Pagenation.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import PageNumber from '@/components/common/pagenation/PageNumber';
 import PageArrowLeftIcon from '@/assets/PageArrowLeftIcon';
 import PageArrowRightIcon from '@/assets/PageArrowRightIcon';
@@ -8,21 +9,42 @@ interface PagenationProps {
   setCurrentPage: (page: number) => void;
 }
 
-const createNumArray = (num: number) => {
-  const newArray = Array.from({ length: num }, (_, idx) => idx + 1);
+/* 예시: createNumArray(3, 5)는 [3, 4, 5, 6, 7] 배열을 반환 */
+const createNumArray = (start: number, size: number) => {
+  const newArray = Array.from({ length: size }, (_, idx) => start + idx);
   return newArray;
 };
 
+const SIZE = 10; // 한 번에 몇 개의 페이지를 보여줄지
+
 export default function Pagenation({ totalPages, currentPage, setCurrentPage }: PagenationProps) {
-  const pageNums = createNumArray(totalPages);
+  const [startPage, setStartPage] = useState(1);
+  let pageNums = createNumArray(startPage, SIZE);
+
+  const isFirst = startPage === 1;
+  const isLast = pageNums.includes(totalPages);
+  const isLastFull = totalPages % SIZE === 0; // 총 페이지 수와 페이지네이션 사이즈가 맞아 떨어지는 경우
+
+  if (isLast && !isLastFull) {
+    const pageNeeded = isFirst ? totalPages % SIZE : totalPages % (startPage - 1);
+    pageNums = pageNums.slice(0, pageNeeded);
+  }
 
   const handlePageNumberClick = (page: number) => {
     setCurrentPage(page);
   };
 
+  const handleNextClick = () => {
+    setStartPage(startPage + SIZE);
+  };
+
+  const handlePrevClick = () => {
+    setStartPage(startPage - SIZE);
+  };
+
   return (
     <div className="flex gap-[2.4rem]">
-      <button type="button">
+      <button type="button" onClick={handlePrevClick} disabled={isFirst}>
         <PageArrowLeftIcon />
       </button>
       <ul className="flex gap-[2.4rem]">
@@ -36,7 +58,7 @@ export default function Pagenation({ totalPages, currentPage, setCurrentPage }: 
           );
         })}
       </ul>
-      <button type="button">
+      <button type="button" onClick={handleNextClick} disabled={isLast}>
         <PageArrowRightIcon />
       </button>
     </div>

--- a/src/constants/Page.tsx
+++ b/src/constants/Page.tsx
@@ -86,7 +86,11 @@ export const PAGES: Pages = {
     },
     announcements: {
       title: '공지사항',
-      page: <TeamAnnouncementsPage />,
+      page: (
+        <PageProvider>
+          <TeamAnnouncementsPage />
+        </PageProvider>
+      ),
       icon: <MegaphoneIcon />,
     },
     posts: {

--- a/src/constants/Page.tsx
+++ b/src/constants/Page.tsx
@@ -10,6 +10,7 @@ import TeamIssuesPage from '@/pages/team/TeamIssuesPage';
 import TeamMainPage from '@/pages/team/TeamMainPage';
 import TeamMembers from '@/pages/team/TeamMembers';
 import TeamPostsPage from '@/pages/team/TeamPostsPage';
+import { PageProvider } from '@/contexts/PageProvider';
 import BoxIcon from '@/assets/BoxIcon';
 import CalendarIcon from '@/assets/CalendarIcon';
 import FolderIcon from '@/assets/FolderIcon';
@@ -54,7 +55,11 @@ export const PAGES: Pages = {
     },
     posts: {
       title: '자유게시판',
-      page: <UserPostsPage />,
+      page: (
+        <PageProvider>
+          <UserPostsPage />
+        </PageProvider>
+      ),
       icon: <FolderIcon />,
     },
     myPage: {
@@ -84,11 +89,11 @@ export const PAGES: Pages = {
       page: <TeamAnnouncementsPage />,
       icon: <MegaphoneIcon />,
     },
-    posts: {
-      title: '자유게시판',
-      page: <TeamPostsPage />,
-      icon: <FolderIcon />,
-    },
+    // posts: {
+    //   title: '자유게시판',
+    //   page: <TeamPostsPage />,
+    //   icon: <FolderIcon />,
+    // }, /* TODO 잠시만.. */
     members: {
       title: '팀원',
       page: <TeamMembers />,

--- a/src/constants/Page.tsx
+++ b/src/constants/Page.tsx
@@ -89,11 +89,15 @@ export const PAGES: Pages = {
       page: <TeamAnnouncementsPage />,
       icon: <MegaphoneIcon />,
     },
-    // posts: {
-    //   title: '자유게시판',
-    //   page: <TeamPostsPage />,
-    //   icon: <FolderIcon />,
-    // }, /* TODO 잠시만.. */
+    posts: {
+      title: '자유게시판',
+      page: (
+        <PageProvider>
+          <TeamPostsPage />
+        </PageProvider>
+      ),
+      icon: <FolderIcon />,
+    },
     members: {
       title: '팀원',
       page: <TeamMembers />,

--- a/src/contexts/PageProvider.tsx
+++ b/src/contexts/PageProvider.tsx
@@ -1,0 +1,106 @@
+/* eslint-disable react-refresh/only-export-components */
+
+/* eslint-disable react-hooks/exhaustive-deps */
+import { ReactNode, createContext, useContext, useEffect, useState } from 'react';
+import { usePostPage } from '@/hooks/usePost';
+import { Post } from '@/types/postTypes';
+
+interface PageContextValue {
+  dataContent: Post[] | [];
+  pageNumsArray: number[];
+  currentPage: number;
+  isFirst: boolean;
+  isLast: boolean;
+  setCurrentPage: (page: number) => void;
+  handlePrevClick: () => void;
+  handleNextClick: () => void;
+  handlePageNumberClick: (page: number) => void;
+}
+
+interface PageProviderProps {
+  children: ReactNode;
+}
+
+const defaultPageValue = {
+  dataContent: [],
+  pageNumsArray: [1],
+  currentPage: 1,
+  isFirst: true,
+  isLast: true,
+  setCurrentPage: () => {},
+  handlePrevClick: () => {},
+  handleNextClick: () => {},
+  handlePageNumberClick: () => {},
+};
+
+/* 예시: createNumArray(3, 5)는 [3, 4, 5, 6, 7] 배열을 반환 */
+const createNumArray = (start: number, size: number) => {
+  const newArray = Array.from({ length: size }, (_, idx) => start + idx);
+  return newArray;
+};
+
+const PageContext = createContext<PageContextValue>(defaultPageValue);
+
+export function PageProvider({ children }: PageProviderProps) {
+  const [currentPage, setCurrentPage] = useState<number>(1);
+  const [startPage, setStartPage] = useState(1);
+
+  const { postPageData, fetchPostPageData } = usePostPage(currentPage);
+
+  const { size, totalPages, content } = postPageData;
+
+  useEffect(() => {
+    fetchPostPageData({ newPath: `/post/user?page=${currentPage}` });
+  }, [currentPage]);
+
+  let pageNumsArray = createNumArray(startPage, size);
+
+  const isFirst = startPage === 1;
+  const isLast = pageNumsArray.includes(totalPages);
+  const isLastFull = totalPages % size === 0; // 총 페이지 수와 페이지네이션 사이즈가 맞아 떨어지는 경우
+
+  if (isLast && !isLastFull) {
+    const pageNeeded = isFirst ? totalPages % size : totalPages % (startPage - 1);
+    pageNumsArray = pageNumsArray.slice(0, pageNeeded);
+  }
+
+  const handlePageNumberClick = (page: number) => {
+    setCurrentPage(page);
+  };
+
+  const handleNextClick = () => {
+    setStartPage(startPage + size);
+  };
+
+  const handlePrevClick = () => {
+    setStartPage(startPage - size);
+  };
+
+  return (
+    <PageContext.Provider
+      value={{
+        dataContent: content,
+        pageNumsArray,
+        currentPage,
+        isFirst,
+        isLast,
+        setCurrentPage,
+        handlePrevClick,
+        handleNextClick,
+        handlePageNumberClick,
+      }}
+    >
+      {children}
+    </PageContext.Provider>
+  );
+}
+
+export function usePagenation() {
+  const pageInfo = useContext(PageContext);
+
+  if (!pageInfo) {
+    throw Error('반드시 PageProvider 안에서 호출해야 합니다.');
+  }
+
+  return pageInfo;
+}

--- a/src/contexts/PageProvider.tsx
+++ b/src/contexts/PageProvider.tsx
@@ -2,11 +2,12 @@
 
 /* eslint-disable react-hooks/exhaustive-deps */
 import { ReactNode, createContext, useContext, useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
 import { usePostPage } from '@/hooks/usePost';
 import { Post } from '@/types/postTypes';
 
 interface PageContextValue {
-  dataContent: Post[] | [];
+  dataContent: Post[] | [] /* TODO 타입 수정 */;
   pageNumsArray: number[];
   currentPage: number;
   isFirst: boolean;
@@ -45,12 +46,20 @@ export function PageProvider({ children }: PageProviderProps) {
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [startPage, setStartPage] = useState(1);
 
+  const { teamId } = useParams();
+  const isTeam = teamId ? true : false;
+
+  /* TODO 수정 */
   const { postPageData, fetchPostPageData } = usePostPage(currentPage);
 
   const { size, totalPages, content } = postPageData;
 
+  const query = `?page=${currentPage}`;
+  const newPath = isTeam ? `/post/team/${teamId}${query}` : `/post/user${query}`;
+
+  /* TODO 여기 부분 path 수정 */
   useEffect(() => {
-    fetchPostPageData({ newPath: `/post/user?page=${currentPage}` });
+    fetchPostPageData({ newPath });
   }, [currentPage]);
 
   let pageNumsArray = createNumArray(startPage, size);

--- a/src/contexts/PageProvider.tsx
+++ b/src/contexts/PageProvider.tsx
@@ -67,6 +67,10 @@ export function PageProvider({ children }: PageProviderProps) {
     content = announcementPageData.content;
   }
 
+  if (totalPages === 0) {
+    totalPages = 1;
+  }
+
   const query = `?page=${currentPage || 1}`;
 
   let newPath: string;

--- a/src/contexts/PageProvider.tsx
+++ b/src/contexts/PageProvider.tsx
@@ -113,8 +113,6 @@ export function PageProvider({ children }: PageProviderProps) {
     setStartPage(startPage - size);
   };
 
-  console.log('content', content);
-
   return (
     <PageContext.Provider
       value={{

--- a/src/hooks/useAnnouncement.ts
+++ b/src/hooks/useAnnouncement.ts
@@ -5,9 +5,7 @@ import { useAxios } from '@/hooks/useAxios';
 import { Announcement, Announcements } from '@/types/announcementTypes';
 
 /* 특정 공지글 조회 용도로 사용하는 경우에만 아규먼트로 announcemnetId를 전달해주면 됩니다. */
-export default function useAnnouncement(announcementId?: number) {
-  const [announcementPageData, setAnnouncementPageData] =
-    useState<Announcements>(DEFAULT_PAGE_DATA);
+export function useAnnouncement(announcementId?: number) {
   const [announcementData, setAnnouncementData] = useState<Announcement[] | []>([]);
 
   const { userId, teamId, pageContent } = useParams();
@@ -18,35 +16,55 @@ export default function useAnnouncement(announcementId?: number) {
   } else {
     if (userId) {
       path = `/announcement/user/unread`; // 유저가 읽지 않은 공지글 조회 @ UserMainPage
-    } else if (pageContent === 'main') {
-      path = `/announcement/team/unread/${teamId}`; // 팀 공지 게시판 조회 @ TeamAnnouncementPage
     } else if (pageContent === 'announcements') {
-      path = `/announcement/team/${teamId}`; // 유저가 읽지 않은 팀 게시글 조회 @ TeamMainPage
+      path = `/announcement/team/${teamId}`; // 팀 공지 게시판 조회 @ TeamAnnouncementPage
     } else {
       throw Error('공지글 데이터를 가져올 수 있는 페이지가 아닙니다.');
     }
   }
 
-  const { loading, error, data, fetchData } = useAxios<Announcements>(
+  const { loading, error, data, fetchData } = useAxios<Announcement[] | []>(
     {
       path,
-      method: 'GET', // TODO 가능하면 다른 요청들도 가능하도록
+      method: 'GET',
     },
     true,
   );
 
   useEffect(() => {
     if (data && !loading) {
-      if (Array.isArray(data)) {
-        setAnnouncementData(data);
-      } else {
-        setAnnouncementPageData(data);
-      }
+      setAnnouncementData(data);
     }
     if (error) {
       throw Error('공지글을 불러오지 못했습니다.');
     }
   }, [loading, error, data]);
 
-  return { announcementPageData, announcementData, fetchAnnouncementData: fetchData };
+  return { announcementData, fetchAnnouncementData: fetchData };
+}
+
+export function useAnnouncementPage(page?: number) {
+  const [announcementPageData, setAnnouncementPageData] =
+    useState<Announcements>(DEFAULT_PAGE_DATA);
+
+  const { teamId } = useParams();
+
+  const query = `?page=${page || 1}`;
+  const path = `/announcement/team/unread/${teamId}${query}`; // 유저가 읽지 않은 팀 게시글 조회 @ TeamMainPage;
+
+  const { loading, error, data, fetchData } = useAxios<Announcements>({
+    path,
+    method: 'GET',
+  });
+
+  useEffect(() => {
+    if (data && !loading) {
+      setAnnouncementPageData(data);
+    }
+    if (error) {
+      throw Error('공지글을 불러오지 못했습니다.');
+    }
+  }, [loading, error, data]);
+
+  return { announcementPageData, fetchAnnouncementPageData: fetchData };
 }

--- a/src/hooks/useAnnouncement.ts
+++ b/src/hooks/useAnnouncement.ts
@@ -16,7 +16,7 @@ export function useAnnouncement(announcementId?: number) {
   } else {
     if (userId) {
       path = `/announcement/user/unread`; // 유저가 읽지 않은 공지글 조회 @ UserMainPage
-    } else if (pageContent === 'announcements') {
+    } else if (pageContent === 'main') {
       path = `/announcement/team/unread/${teamId}`; // 유저가 읽지 않은 팀 게시글 조회 @ TeamMainPage;
     } else {
       throw Error('공지글 데이터를 가져올 수 있는 페이지가 아닙니다.');

--- a/src/hooks/useAnnouncement.ts
+++ b/src/hooks/useAnnouncement.ts
@@ -17,7 +17,7 @@ export function useAnnouncement(announcementId?: number) {
     if (userId) {
       path = `/announcement/user/unread`; // 유저가 읽지 않은 공지글 조회 @ UserMainPage
     } else if (pageContent === 'announcements') {
-      path = `/announcement/team/${teamId}`; // 팀 공지 게시판 조회 @ TeamAnnouncementPage
+      path = `/announcement/team/unread/${teamId}`; // 유저가 읽지 않은 팀 게시글 조회 @ TeamMainPage;
     } else {
       throw Error('공지글 데이터를 가져올 수 있는 페이지가 아닙니다.');
     }
@@ -50,7 +50,7 @@ export function useAnnouncementPage(page?: number) {
   const { teamId } = useParams();
 
   const query = `?page=${page || 1}`;
-  const path = `/announcement/team/unread/${teamId}${query}`; // 유저가 읽지 않은 팀 게시글 조회 @ TeamMainPage;
+  const path = `/announcement/team/${teamId}${query}`; // 팀 공지 게시판 조회 @ TeamAnnouncementPage
 
   const { loading, error, data, fetchData } = useAxios<Announcements>({
     path,

--- a/src/hooks/usePost.ts
+++ b/src/hooks/usePost.ts
@@ -18,7 +18,7 @@ export function usePost(postId?: number) {
   const { loading, error, data, fetchData } = useAxios<Post[] | []>(
     {
       path,
-      method: 'GET', // TODO 가능하면 다른 요청들도 가능하도록
+      method: 'GET',
     },
     true,
   );
@@ -51,7 +51,7 @@ export function usePostPage(page?: number) {
 
   const { loading, error, data, fetchData } = useAxios<Posts>({
     path,
-    method: 'GET', // TODO 가능하면 다른 요청들도 가능하도록
+    method: 'GET',
   });
 
   useEffect(() => {

--- a/src/hooks/usePost.ts
+++ b/src/hooks/usePost.ts
@@ -5,23 +5,48 @@ import { useAxios } from '@/hooks/useAxios';
 import { Post, Posts } from '@/types/postTypes';
 
 /* 특정 게시글 조회 용도로 사용하는 경우에만 아규먼트로 postId를 전달해주면 됩니다. */
-export default function usePost(postId?: number) {
-  const [postPageData, setPostPageData] = useState<Posts>(DEFAULT_PAGE_DATA);
+export function usePost(postId?: number) {
   const [postData, setPostData] = useState<Post[] | []>([]);
-
-  const { userId, teamId } = useParams();
 
   let path = '';
   if (postId) {
     path = `/post/${postId}`; // 특정 게시글 조회
   } else {
-    if (userId) {
-      path = `/post/user`; // 유저의 팀 통합 자유게시판 조회 @ UserPostsPage
-    } else if (teamId) {
-      path = `/post/team/${teamId}`; // 팀의 자유게시판 조회 @ TeamPostsPage
-    } else {
-      throw Error('게시글 데이터를 가져올 수 있는 페이지가 아닙니다.');
+    throw Error('게시글 데이터를 가져올 수 있는 페이지가 아닙니다.');
+  }
+
+  const { loading, error, data, fetchData } = useAxios<Post[] | []>(
+    {
+      path,
+      method: 'GET', // TODO 가능하면 다른 요청들도 가능하도록
+    },
+    true,
+  );
+
+  useEffect(() => {
+    if (data && !loading) {
+      setPostData(data);
     }
+    if (error) {
+      throw Error('게시글을 불러오지 못했습니다.');
+    }
+  }, [loading, error, data]);
+
+  return { postData, fetchPostData: fetchData };
+}
+
+export function usePostPage(page?: number) {
+  const [postPageData, setPostPageData] = useState<Posts>(DEFAULT_PAGE_DATA);
+
+  const { userId, teamId } = useParams();
+
+  const query = `?page=${page || 1}`;
+
+  let path = '';
+  if (userId) {
+    path = `/post/user${query}`; // 유저의 팀 통합 자유게시판 조회 @ UserPostsPage
+  } else if (teamId) {
+    path = `/post/team/${teamId}${query}`; // 팀의 자유게시판 조회 @ TeamPostsPage 자유게시판 조회 @ TeamPostsPage
   }
 
   const { loading, error, data, fetchData } = useAxios<Posts>(
@@ -34,16 +59,12 @@ export default function usePost(postId?: number) {
 
   useEffect(() => {
     if (data && !loading) {
-      if (Array.isArray(data)) {
-        setPostData(data);
-      } else {
-        setPostPageData(data);
-      }
+      setPostPageData(data);
     }
     if (error) {
       throw Error('게시글을 불러오지 못했습니다.');
     }
   }, [loading, error, data]);
 
-  return { postPageData, postData, fetchPostData: fetchData };
+  return { postPageData, fetchPostPageData: fetchData };
 }

--- a/src/hooks/usePost.ts
+++ b/src/hooks/usePost.ts
@@ -49,13 +49,10 @@ export function usePostPage(page?: number) {
     path = `/post/team/${teamId}${query}`; // 팀의 자유게시판 조회 @ TeamPostsPage 자유게시판 조회 @ TeamPostsPage
   }
 
-  const { loading, error, data, fetchData } = useAxios<Posts>(
-    {
-      path,
-      method: 'GET', // TODO 가능하면 다른 요청들도 가능하도록
-    },
-    true,
-  );
+  const { loading, error, data, fetchData } = useAxios<Posts>({
+    path,
+    method: 'GET', // TODO 가능하면 다른 요청들도 가능하도록
+  });
 
   useEffect(() => {
     if (data && !loading) {

--- a/src/pages/UserMainPage.tsx
+++ b/src/pages/UserMainPage.tsx
@@ -2,7 +2,7 @@ import BoardSection from '@/components/common/BoardSection';
 import MainSchedules from '@/components/MainPage/MainSchedules';
 import AnnouncementList from '@/components/announcement/AnnouncementList';
 import KanbanBoard from '@/components/kanbanBoard/KanbanBoard';
-import useAnnouncement from '@/hooks/useAnnouncement';
+import { useAnnouncement } from '@/hooks/useAnnouncement';
 import useIssue from '@/hooks/useIssue';
 
 export default function UserMainPage() {

--- a/src/pages/UserPostsPage.tsx
+++ b/src/pages/UserPostsPage.tsx
@@ -1,30 +1,17 @@
-import { useEffect, useState } from 'react';
+/* eslint-disable react-hooks/exhaustive-deps */
 import BoardSection from '@/components/common/BoardSection';
 import Pagenation from '@/components/common/pagenation/Pagenation';
 import PostList from '@/components/Post/PostList';
-import { usePostPage } from '@/hooks/usePost';
+import { usePagenation } from '@/contexts/PageProvider';
 
 export default function UserPostsPage() {
-  /* TODO 받아온 데이터의 pageNumber로 알 수 있을 것 같기도? */
-  const [currentPage, setCurrentPage] = useState<number>(1);
-
-  const { postPageData, fetchPostPageData } = usePostPage(currentPage);
-
-  const { totalPages, content } = postPageData;
-
-  useEffect(() => {
-    fetchPostPageData({ newPath: `/post/user?page=${currentPage}` });
-  }, [currentPage]);
+  const { dataContent } = usePagenation();
 
   return (
     <BoardSection title="Bulletin board">
       <div className="flex flex-col items-center gap-[4.6rem]">
-        <PostList posts={content} />
-        <Pagenation
-          totalPages={totalPages}
-          currentPage={currentPage}
-          setCurrentPage={setCurrentPage}
-        />
+        <PostList posts={dataContent} />
+        <Pagenation />
       </div>
     </BoardSection>
   );

--- a/src/pages/UserPostsPage.tsx
+++ b/src/pages/UserPostsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import BoardSection from '@/components/common/BoardSection';
 import Pagenation from '@/components/common/pagenation/Pagenation';
 import PostList from '@/components/Post/PostList';
@@ -6,11 +6,15 @@ import { usePostPage } from '@/hooks/usePost';
 
 export default function UserPostsPage() {
   const [currentPage, setCurrentPage] = useState<number>(1);
-  console.log('currentPage', currentPage);
 
   const {
     postPageData: { content },
-  } = usePostPage(1);
+    fetchPostPageData,
+  } = usePostPage(currentPage);
+
+  useEffect(() => {
+    fetchPostPageData({ newPath: `/post/user?page=${currentPage}` });
+  }, [currentPage]);
 
   return (
     <BoardSection title="Bulletin board">

--- a/src/pages/UserPostsPage.tsx
+++ b/src/pages/UserPostsPage.tsx
@@ -10,8 +10,7 @@ export default function UserPostsPage() {
 
   const { postPageData, fetchPostPageData } = usePostPage(currentPage);
 
-  const { totalPages, totalElements, content } = postPageData;
-  console.log(totalPages, totalElements);
+  const { totalPages, content } = postPageData;
 
   useEffect(() => {
     fetchPostPageData({ newPath: `/post/user?page=${currentPage}` });

--- a/src/pages/UserPostsPage.tsx
+++ b/src/pages/UserPostsPage.tsx
@@ -2,6 +2,7 @@ import BoardSection from '@/components/common/BoardSection';
 import Pagenation from '@/components/common/pagenation/Pagenation';
 import PostList from '@/components/Post/PostList';
 import { usePagenation } from '@/contexts/PageProvider';
+import { Post } from '@/types/postTypes';
 
 export default function UserPostsPage() {
   const { dataContent } = usePagenation();
@@ -9,7 +10,7 @@ export default function UserPostsPage() {
   return (
     <BoardSection title="Bulletin board">
       <div className="flex flex-col items-center gap-[4.6rem]">
-        <PostList posts={dataContent} />
+        <PostList posts={dataContent as Post[]} />
         <Pagenation />
       </div>
     </BoardSection>

--- a/src/pages/UserPostsPage.tsx
+++ b/src/pages/UserPostsPage.tsx
@@ -5,12 +5,13 @@ import PostList from '@/components/Post/PostList';
 import { usePostPage } from '@/hooks/usePost';
 
 export default function UserPostsPage() {
+  /* TODO 받아온 데이터의 pageNumber로 알 수 있을 것 같기도? */
   const [currentPage, setCurrentPage] = useState<number>(1);
 
-  const {
-    postPageData: { content },
-    fetchPostPageData,
-  } = usePostPage(currentPage);
+  const { postPageData, fetchPostPageData } = usePostPage(currentPage);
+
+  const { totalPages, totalElements, content } = postPageData;
+  console.log(totalPages, totalElements);
 
   useEffect(() => {
     fetchPostPageData({ newPath: `/post/user?page=${currentPage}` });
@@ -20,7 +21,11 @@ export default function UserPostsPage() {
     <BoardSection title="Bulletin board">
       <div className="flex flex-col items-center gap-[4.6rem]">
         <PostList posts={content} />
-        <Pagenation currentPage={currentPage} setCurrentPage={setCurrentPage} />
+        <Pagenation
+          totalPages={totalPages}
+          currentPage={currentPage}
+          setCurrentPage={setCurrentPage}
+        />
       </div>
     </BoardSection>
   );

--- a/src/pages/UserPostsPage.tsx
+++ b/src/pages/UserPostsPage.tsx
@@ -2,19 +2,21 @@ import { useState } from 'react';
 import BoardSection from '@/components/common/BoardSection';
 import Pagenation from '@/components/common/pagenation/Pagenation';
 import PostList from '@/components/Post/PostList';
-import usePost from '@/hooks/usePost';
+import { usePostPage } from '@/hooks/usePost';
 
 export default function UserPostsPage() {
   const [currentPage, setCurrentPage] = useState<number>(1);
+  console.log('currentPage', currentPage);
+
   const {
     postPageData: { content },
-  } = usePost();
+  } = usePostPage(1);
 
   return (
     <BoardSection title="Bulletin board">
       <div className="flex flex-col items-center gap-[4.6rem]">
-        <PostList posts={content || []} />
-        <Pagenation currentPage={currentPage} />
+        <PostList posts={content} />
+        <Pagenation currentPage={currentPage} setCurrentPage={setCurrentPage} />
       </div>
     </BoardSection>
   );

--- a/src/pages/UserPostsPage.tsx
+++ b/src/pages/UserPostsPage.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/exhaustive-deps */
 import BoardSection from '@/components/common/BoardSection';
 import Pagenation from '@/components/common/pagenation/Pagenation';
 import PostList from '@/components/Post/PostList';

--- a/src/pages/UserPostsPage.tsx
+++ b/src/pages/UserPostsPage.tsx
@@ -1,11 +1,21 @@
+import { useState } from 'react';
 import BoardSection from '@/components/common/BoardSection';
+import Pagenation from '@/components/common/pagenation/Pagenation';
 import PostList from '@/components/Post/PostList';
 import usePost from '@/hooks/usePost';
 
 export default function UserPostsPage() {
+  const [currentPage, setCurrentPage] = useState<number>(1);
   const {
     postPageData: { content },
   } = usePost();
 
-  return <BoardSection title="Bulletin board" content={<PostList posts={content || []} />} />;
+  return (
+    <BoardSection title="Bulletin board">
+      <div className="flex flex-col items-center gap-[4.6rem]">
+        <PostList posts={content || []} />
+        <Pagenation currentPage={currentPage} />
+      </div>
+    </BoardSection>
+  );
 }

--- a/src/pages/team/TeamAnnouncementsPage.tsx
+++ b/src/pages/team/TeamAnnouncementsPage.tsx
@@ -1,9 +1,9 @@
 import BoardSection from '@/components/common/BoardSection';
 import AnnouncementPageList from '@/components/announcement/AnnouncementPageList';
-import useAnnouncement from '@/hooks/useAnnouncement';
+import { useAnnouncementPage } from '@/hooks/useAnnouncement';
 
 export default function TeamAnnouncementsPage() {
-  const { announcementPageData } = useAnnouncement();
+  const { announcementPageData } = useAnnouncementPage();
 
   return (
     <BoardSection

--- a/src/pages/team/TeamAnnouncementsPage.tsx
+++ b/src/pages/team/TeamAnnouncementsPage.tsx
@@ -1,14 +1,20 @@
 import BoardSection from '@/components/common/BoardSection';
+import Pagenation from '@/components/common/pagenation/Pagenation';
 import AnnouncementPageList from '@/components/announcement/AnnouncementPageList';
-import { useAnnouncementPage } from '@/hooks/useAnnouncement';
+import { usePagenation } from '@/contexts/PageProvider';
+import { Announcement } from '@/types/announcementTypes';
 
 export default function TeamAnnouncementsPage() {
-  const { announcementPageData } = useAnnouncementPage();
+  const { dataContent } = usePagenation();
+
+  // console.log('dataContent', dataContent);
 
   return (
-    <BoardSection
-      title="Notice"
-      content={<AnnouncementPageList announcements={announcementPageData} />}
-    />
+    <BoardSection title="Notice">
+      <div className="flex flex-col items-center gap-[4.6rem]">
+        <AnnouncementPageList announcements={dataContent as Announcement[]} />
+        <Pagenation />
+      </div>
+    </BoardSection>
   );
 }

--- a/src/pages/team/TeamAnnouncementsPage.tsx
+++ b/src/pages/team/TeamAnnouncementsPage.tsx
@@ -7,8 +7,6 @@ import { Announcement } from '@/types/announcementTypes';
 export default function TeamAnnouncementsPage() {
   const { dataContent } = usePagenation();
 
-  // console.log('dataContent', dataContent);
-
   return (
     <BoardSection title="Notice">
       <div className="flex flex-col items-center gap-[4.6rem]">

--- a/src/pages/team/TeamMainPage.tsx
+++ b/src/pages/team/TeamMainPage.tsx
@@ -4,7 +4,7 @@ import MainSchedules from '@/components/MainPage/MainSchedules';
 import AnnouncementList from '@/components/announcement/AnnouncementList';
 import KanbanBoard from '@/components/kanbanBoard/KanbanBoard';
 import { useTeam } from '@/contexts/TeamProvider';
-import useAnnouncement from '@/hooks/useAnnouncement';
+import { useAnnouncement } from '@/hooks/useAnnouncement';
 import useIssue from '@/hooks/useIssue';
 
 export default function TeamMainPage() {

--- a/src/pages/team/TeamPostsPage.tsx
+++ b/src/pages/team/TeamPostsPage.tsx
@@ -2,6 +2,7 @@ import BoardSection from '@/components/common/BoardSection';
 import Pagenation from '@/components/common/pagenation/Pagenation';
 import PostList from '@/components/Post/PostList';
 import { usePagenation } from '@/contexts/PageProvider';
+import { Post } from '@/types/postTypes';
 
 /* TODO 페이지네이션 생기면서 UserPostPage와 파일이 완전히 동일해짐 */
 export default function TeamPostsPage() {
@@ -10,7 +11,7 @@ export default function TeamPostsPage() {
   return (
     <BoardSection title="Bulletin board">
       <div className="flex flex-col items-center gap-[4.6rem]">
-        <PostList posts={dataContent} />
+        <PostList posts={dataContent as Post[]} />
         <Pagenation />
       </div>
     </BoardSection>

--- a/src/pages/team/TeamPostsPage.tsx
+++ b/src/pages/team/TeamPostsPage.tsx
@@ -1,11 +1,18 @@
 import BoardSection from '@/components/common/BoardSection';
+import Pagenation from '@/components/common/pagenation/Pagenation';
 import PostList from '@/components/Post/PostList';
-import usePost from '@/hooks/usePost';
+import { usePagenation } from '@/contexts/PageProvider';
 
+/* TODO 페이지네이션 생기면서 UserPostPage와 파일이 완전히 동일해짐 */
 export default function TeamPostsPage() {
-  const {
-    postPageData: { content },
-  } = usePost();
+  const { dataContent } = usePagenation();
 
-  return <BoardSection title="Bulletin board" content={<PostList posts={content || []} />} />;
+  return (
+    <BoardSection title="Bulletin board">
+      <div className="flex flex-col items-center gap-[4.6rem]">
+        <PostList posts={dataContent} />
+        <Pagenation />
+      </div>
+    </BoardSection>
+  );
 }


### PR DESCRIPTION
## 주요 구현 사항 ✨
- 페이지네이션 구현해서 공지사항, 자유게시판 페이지에 적용해두었습니다.

## 스크린샷 🎨
![image](https://github.com/codeit-part4-8team-project/main/assets/148641571/917f1aee-6403-4771-816c-4412ded84553)

## 구체적 구현 사항 설명 📃
- 페이지네이션 사용하는 페이지들은 페이지 상수에서 PageProvider로 감싸주었습니다.
- 구체적인 구현 사항 설명은 셀프 리뷰로 남겨두겠습니다.

## 논의사항 🤔
- 지금 PageProvider 안에 로직이 if문으로 분기하는 부분도 많고 몹시 지저분합니다... 마음에는 안 들지만 일단은 동작하게는 만들어두었는데 우선은 이 정도 선에서 PR 올리고 개선은 나중에 해보는 걸로 하겠습니다. 
