### PR TITLE
Fix: 자잘한 UI 문제들 수정 및 백엔드 요청 경로 수정 사항 반영

### DIFF
--- a/src/components/Post/PostList.tsx
+++ b/src/components/Post/PostList.tsx
@@ -36,15 +36,13 @@ export default function PostList({ posts }: PostListProps) {
           </NoCard>
         )}
       </ul>
-      {teamId && (
-        <TextButton
-          buttonSize="sm"
-          onClick={handleModalClick}
-          className="absolute right-12 top-[3.6rem]"
-        >
-          작성하기
-        </TextButton>
-      )}
+      <TextButton
+        buttonSize="sm"
+        onClick={handleModalClick}
+        className="absolute right-12 top-[3.6rem]"
+      >
+        작성하기
+      </TextButton>
     </>
   );
 }

--- a/src/components/TeamsPage/TeamTab.tsx
+++ b/src/components/TeamsPage/TeamTab.tsx
@@ -8,7 +8,7 @@ export default function TeamTab() {
   const teamPageList = Object.keys(PAGES.team) as TeamPageType[];
 
   return (
-    <ul className="flex w-fit items-center gap-[2.4rem]">
+    <ul className="flex w-fit min-w-[55.8rem] items-center gap-[2.4rem]">
       {teamPageList.map((page, idx) => {
         const { title } = PAGES.team[page] as Page;
         const isCurrent = page === pageContent ? true : false;

--- a/src/components/announcement/AnnouncementPageList.tsx
+++ b/src/components/announcement/AnnouncementPageList.tsx
@@ -27,7 +27,7 @@ export default function AnnouncementPageList({ announcements }: AnnouncementPage
 
   return (
     <>
-      <div className="w-[132.6rem]">
+      <div className="w-full">
         {announcements.length !== 0 ? (
           <ul className="grid w-fit list-none grid-cols-3 gap-[2.4rem]">
             {announcements.map((announcement) => {

--- a/src/components/common/BoardSection.tsx
+++ b/src/components/common/BoardSection.tsx
@@ -30,10 +30,12 @@ export default function BoardSection({ title, content, mode, children }: BoardSe
   const controlDateMode = mode === 'week' ? 'week' : 'month';
   const shouldDisplayControlDate = title === 'My calendar' || title === 'Team calendar';
   const gapBetweenTitleAndContent = clsx({
-    'gap-[1.6rem]': pageContent === ('main' || 'issue'),
+    'gap-[1.6rem]': pageContent === 'main',
     'gap-12': pageContent === 'schedule',
     'gap-[6.4rem]': pageContent === 'announcement',
     'gap-[2.8rem]': pageContent === 'member',
+    'gap-[2.4rem]': pageContent === 'post',
+    'gap-[3.8rem]': pageContent === 'issue',
   });
 
   return (

--- a/src/components/common/ProfileStack.tsx
+++ b/src/components/common/ProfileStack.tsx
@@ -15,7 +15,7 @@ export default function ProfileStack({ profileImgs, size }: ProfileStackProps) {
   });
 
   return (
-    <div className="flex">
+    <div className="flex min-w-[3.6rem]">
       {profileImgs.map((profile, idx) => {
         const imageClasses = clsx({
           'mr-0 z-0': idx === profileImgs.length - 1, // 2번 인덱스

--- a/src/components/common/sideBar/SideBar.tsx
+++ b/src/components/common/sideBar/SideBar.tsx
@@ -25,7 +25,7 @@ function ProfileSection() {
   const { user } = useUserContext();
 
   return (
-    <Link to={`/user/${user?.id}/myPage`}>
+    <Link to={`/user/${user?.id}/mypage`}>
       <div className="my-[3.3rem] ml-16 flex items-center gap-[1.6rem]">
         <img
           src={user ? user.imageUrl : ProfileImg}

--- a/src/components/common/sideBar/SideBar.tsx
+++ b/src/components/common/sideBar/SideBar.tsx
@@ -13,7 +13,7 @@ import PlusCircleIcon from '@/assets/PlusCircleIcon';
 
 export default function SideBar() {
   return (
-    <div className="fixed bottom-0 left-0 top-[8.2rem] w-[26rem] rounded-tr-3xl bg-gray100">
+    <div className="fixed bottom-0 left-0 top-[8.2rem] z-50 w-[26rem] rounded-tr-3xl bg-gray100">
       <ProfileSection />
       <BoardList />
       <GroupSection />

--- a/src/components/common/sideBar/SideBar.tsx
+++ b/src/components/common/sideBar/SideBar.tsx
@@ -8,7 +8,7 @@ import GroupModal from '@/components/Modal/GroupModal';
 import { useModal } from '@/contexts/ModalProvider';
 import { useUserContext } from '@/contexts/UserProvider';
 import { useAxios } from '@/hooks/useAxios';
-import { Team, Teams } from '@/types/teamTypes';
+import { Team } from '@/types/teamTypes';
 import PlusCircleIcon from '@/assets/PlusCircleIcon';
 
 export default function SideBar() {
@@ -41,16 +41,16 @@ function ProfileSection() {
 function GroupSection() {
   const [teams, setTeams] = useState<Team[]>([]);
 
-  const { loading, error, data } = useAxios<Teams>(
+  const { loading, error, data } = useAxios<Team[] | []>(
     {
-      path: '/team/my-team',
+      path: '/team/',
       method: 'GET',
     },
     true,
   );
   useEffect(() => {
     if (data && !loading) {
-      setTeams(data.content);
+      setTeams(data);
     }
     if (error) {
       throw Error('내가 속한 팀을 불러올 수 없습니다.');

--- a/src/components/kanbanBoard/KanbanBoard.tsx
+++ b/src/components/kanbanBoard/KanbanBoard.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import { useEffect } from 'react';
 import clsx from 'clsx';
 import TextButton from '@/components/common/TextButton';
@@ -43,7 +44,8 @@ export default function KanbanBoard({
 
   const kanbanBoardClasses = clsx({
     'justify-between h-full w-content': type === 'main',
-    'justify-center absolute top-[3.7rem] bottom-[2.4rem] left-0 right-0': type === 'page',
+    'justify-center h-full min-[1870px]:absolute top-[3.7rem] bottom-[2.4rem] left-0 right-0':
+      type === 'page',
   });
 
   return (


### PR DESCRIPTION
## 주요 구현 사항 ✨
- 자잘한 문제들 수정

## 스크린샷 🎨

## 구체적 구현 사항 설명 📃
### 1. 사이드바 툴팁 오른쪽 가려져 보이지 않던 문제 해결
![image](https://github.com/codeit-part4-8team-project/main/assets/148641571/cf1d39aa-db89-4cca-b67c-8628098b90f8)

### 2. 사이드바 프로필 부분 마이페이지 링크 'myPage' -> 'mypage'로 변경
![image](https://github.com/codeit-part4-8team-project/main/assets/148641571/06367df3-e6ae-468f-b862-67af0e695ad2)

### 3. 사이드바 그룹 - 백엔드 요청 경로 수정 사항 반영

### 4. 유저 자유게시판 버튼 다시 추가
![image](https://github.com/codeit-part4-8team-project/main/assets/148641571/442909ec-3ece-4eed-9334-c3fa4cbcd00c)

### 5. 기준보다 작은 화면에서 이슈 페이지 타이틀 가려 보이지 않던 문제 해결
- 디자인에는 없기는 한데 작은 화면에서 타이틀 보이지 않는 문제는 해결해야 할 것 같아서 임의로 반응형 줬습니다.
![image](https://github.com/codeit-part4-8team-project/main/assets/148641571/d071f6da-a196-410d-ad93-39077622578f)
⬇️
![Apr-03-2024 15-18-43](https://github.com/codeit-part4-8team-project/main/assets/148641571/b9daed3c-3f22-4998-9b8a-2293074cf2dc)

### 6. 팀 상단 바 min-width 지정하여 두 줄 되지 않도록
![image](https://github.com/codeit-part4-8team-project/main/assets/148641571/667476f0-0aa7-459b-be56-a072d0c6393c)
⬇️
![image](https://github.com/codeit-part4-8team-project/main/assets/148641571/5e799552-8440-4d96-ad4c-d89747c2a686)

## 논의사항 🤔

-
