### PR TITLE
Feat: 유저 정보 편집 폼 유효성 검증 업데이트

### DIFF
--- a/src/components/Modal/EditProfileModal.tsx
+++ b/src/components/Modal/EditProfileModal.tsx
@@ -217,7 +217,7 @@ export default function EditProfileModal({ handleClose, userContext }: EditProfi
                 autoComplete="off"
               >
                 <InputValidateMessage
-                  isError={errors.username?.message}
+                  isError={dirtyFields.username && errors.username?.message}
                   errorMessage={errors.username?.message}
                   isValid={isUniqueUsername || !dirtyFields.username}
                   validMessage="사용 가능한 닉네임입니다."

--- a/src/components/Modal/EditProfileModal.tsx
+++ b/src/components/Modal/EditProfileModal.tsx
@@ -26,11 +26,12 @@ interface UserEditForm {
 export default function EditProfileModal({ handleClose, userContext }: EditProfileModalProps) {
   const { refetch } = usePagenation();
   const { user, setUser } = userContext;
-  const [isUniqueUsername, setIsUniqueUsername] = useState<boolean>(false);
+  const [isUniqueUsername, setIsUniqueUsername] = useState<boolean>(true);
 
   const {
     data: unavailableUsername,
     error: checkUsernameError,
+    loading,
     fetchData: fetchCheckUsername,
   } = useAxios<boolean>({
     path: `user/checkUsername/${user?.username}`,
@@ -44,7 +45,7 @@ export default function EditProfileModal({ handleClose, userContext }: EditProfi
     clearErrors,
     getValues,
     watch,
-    formState: { isValid, errors },
+    formState: { isValid, errors, dirtyFields },
     trigger,
   } = useForm<UserEditForm>({
     mode: 'all',
@@ -87,7 +88,6 @@ export default function EditProfileModal({ handleClose, userContext }: EditProfi
 
       if (fetchUserResponse.status === 'fulfilled') {
         setUser(fetchUserResponse.value.data);
-        console.log(refetch);
         refetch && refetch(); //유저네임 바뀌는 것 때문에 팀 히스토리 쪽 모달에 문제생겨서 유
         handleClose();
       } else if (fetchUserResponse.status === 'rejected') {
@@ -115,16 +115,18 @@ export default function EditProfileModal({ handleClose, userContext }: EditProfi
   useEffect(() => {
     if (unavailableUsername === true) {
       setError('username', { type: 'duplicated', message: '이미 사용중인 닉네임입니다.' });
+      setIsUniqueUsername(() => false);
+      trigger('username', { shouldFocus: true });
     } else if (unavailableUsername === false) {
-      setIsUniqueUsername(true);
-      console.log('사용가능한 닉네임입니다.');
       clearErrors('username');
-      trigger('username');
+      setIsUniqueUsername(() => true);
+      trigger('username', { shouldFocus: true });
     }
+    trigger();
     if (checkUsernameError) {
       alert(checkUsernameError.message || '닉네임 중복확인에 실패하였습니다');
     }
-  }, [unavailableUsername, checkUsernameError]);
+  }, [unavailableUsername, checkUsernameError, loading]);
 
   return (
     <ModalLayout title="프로필 변경" closeClick={handleClose}>
@@ -162,18 +164,19 @@ export default function EditProfileModal({ handleClose, userContext }: EditProfi
           <div className="flex w-full flex-col gap-8">
             <Input
               register={register('name', {
+                required: '이름을 입력해주세요',
                 maxLength: {
                   value: 20,
                   message: '20자 이하로 작성해주세요',
                 },
                 pattern: {
                   value: /^[가-힣A-Za-z]+$/,
-                  message: '성함은 한글, 알파벳만 사용할 수 있습니다.',
+                  message: '이름은 한글, 알파벳만 사용할 수 있습니다.',
                 },
               })}
               id="name"
               name="name"
-              label="성함"
+              label="이름"
               type="text"
               autoComplete="off"
             >
@@ -186,29 +189,29 @@ export default function EditProfileModal({ handleClose, userContext }: EditProfi
             <div className="flex gap-[1.2rem]">
               <Input
                 register={register('username', {
-                  required: true,
+                  required: '유저네임을 입력해주세요',
                   minLength: {
                     value: 5,
-                    message: '닉네임은 5자 이상, 30자 이하여야 합니다.',
+                    message: '유저네임은 5자 이상, 30자 이하여야 합니다.',
                   },
                   maxLength: {
                     value: 30,
-                    message: '닉네임은 5자 이상, 30자 이하여야 합니다.',
+                    message: '유저네임은 5자 이상, 30자 이하여야 합니다.',
                   },
                   pattern: {
                     value: /^[가-힣a-zA-Z0-9_-]+$/,
-                    message: '닉네임은 한글, 알파벳, 숫자, 밑줄(_),(-)만 사용할 수 있습니다.',
+                    message: '유저네임은 한글, 알파벳, 숫자, 밑줄(_),(-)만 사용할 수 있습니다.',
                   },
                   validate: {
                     checkAvailable: () =>
-                      unavailableUsername === false || '닉네임 중복을 확인해주세요',
+                      !dirtyFields.username || isUniqueUsername || '닉네임 중복을 확인해주세요',
                   },
                   onChange: () => {
                     setIsUniqueUsername(false);
                   },
                 })}
                 id="username"
-                label="username"
+                label="유저네임"
                 type="text"
                 placeholder={user?.username}
                 autoComplete="off"
@@ -216,7 +219,7 @@ export default function EditProfileModal({ handleClose, userContext }: EditProfi
                 <InputValidateMessage
                   isError={errors.username?.message}
                   errorMessage={errors.username?.message}
-                  isValid={isUniqueUsername}
+                  isValid={isUniqueUsername || !dirtyFields.username}
                   validMessage="사용 가능한 닉네임입니다."
                 />
               </Input>
@@ -242,9 +245,11 @@ export default function EditProfileModal({ handleClose, userContext }: EditProfi
               placeholder="간단한 자기소개를 입력해주세요."
               autoComplete="off"
             >
-              <span className="self-end text-body5-regular leading-[2.2rem] text-gray50">
-                {`${watch('bio')?.length || 0}/20`}
-              </span>
+              <InputValidateMessage
+                isError={errors.bio?.message}
+                errorMessage={errors.bio?.message}
+                watchMessage={`${watch('bio')?.length || 0}/20`}
+              />
             </Input>
           </div>
         </form>

--- a/src/components/SignupPage/EnterUserStepContent.tsx
+++ b/src/components/SignupPage/EnterUserStepContent.tsx
@@ -213,7 +213,7 @@ function EnterUserStepContent() {
               placeholder={user?.username}
             >
               <InputValidateMessage
-                isError={!dirtyFields.username && errors.username?.message}
+                isError={dirtyFields.username && errors.username?.message}
                 errorMessage={errors.username?.message}
                 isValid={isUniqueUsername || !dirtyFields.username}
                 validMessage="사용 가능한 닉네임입니다."

--- a/src/components/SignupPage/SignupLayout.tsx
+++ b/src/components/SignupPage/SignupLayout.tsx
@@ -3,8 +3,10 @@ import { useNavigate } from 'react-router-dom';
 import clsx from 'clsx';
 import TextButton from '../common/TextButton';
 import { useStepContext } from '@/contexts/SignupStepProvider';
+import { useUserContext } from '@/contexts/UserProvider';
 
 function SignupLayout({ children }: { children: ReactNode }) {
+  const { user } = useUserContext();
   const { step, setStep, formValidity } = useStepContext();
   const navigate = useNavigate();
 
@@ -20,7 +22,7 @@ function SignupLayout({ children }: { children: ReactNode }) {
   const handleNextStepButtonClick = (currentStep: number) => {
     if (currentStep === 3) {
       return () => {
-        navigate('user/main');
+        navigate(`/user/${user?.id}/main`);
       };
     }
   };

--- a/src/hooks/useAxios.ts
+++ b/src/hooks/useAxios.ts
@@ -82,7 +82,7 @@ defaultInstance.interceptors.response.use(
 interface UseAxiosParams<T> {
   path?: string;
   method?: Method;
-  data?: T | Record<string, never>;
+  data?: T | unknown;
 }
 
 export type Trigger = ({


### PR DESCRIPTION
## 주요 구현 사항 ✨
- 유저네임 확인 후 유효할 시 인풋 아래 초록색 valid message 뜨도록.
- 기존 유저네임을 유지한 상태로도 폼을 변경할 수 있도록
- 이전 중복 확인으로 ok 응답을 얻었더라도 다른 유저네임을 제출 시도 시 폼 제출이 불가하도록.

## 스크린샷 🎨

https://github.com/codeit-part4-8team-project/main/assets/121015462/eedcb300-1078-4ef8-aa54-ce63d2f20cda



## 구체적 구현 사항 설명 📃

-

## 논의사항 🤔

-
