### PR TITLE
Feat: 회원탈퇴, 로그아웃 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "8team-project",
+  "name": "keepy-uppy",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "8team-project",
+      "name": "keepy-uppy",
       "version": "0.0.0",
       "dependencies": {
         "@types/react-router-dom": "^5.3.3",

--- a/src/components/Modal/ManageTeamHistoryModal.tsx
+++ b/src/components/Modal/ManageTeamHistoryModal.tsx
@@ -1,7 +1,7 @@
 import { MEMBER } from '@/constants/Team';
 import { Controller, SubmitHandler, useForm } from 'react-hook-form';
-import Dropdown from '../common/Dropdown';
 import Input, { InputValidateMessage } from '../common/Input';
+import SelectBoxDropdown from '../common/SelectBoxDropdown';
 import TextButton from '../common/TextButton';
 import ModalLayout from '../common/modal/ModalLayout';
 import { HttpStatusCode } from 'axios';
@@ -161,7 +161,7 @@ export default function ManageTeamHistoryModal({ me, team, onClose }: ManageTeam
                 name="role"
                 control={control}
                 render={({ field }) => (
-                  <Dropdown
+                  <SelectBoxDropdown
                     options={Object.values(MEMBER.ROLE)}
                     selectedOption={field.value}
                     onSelect={(value) => {

--- a/src/components/Mypage/DeleteAccountButton.tsx
+++ b/src/components/Mypage/DeleteAccountButton.tsx
@@ -1,0 +1,36 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAxios } from '@/hooks/useAxios';
+
+export default function DeleteAccountButton() {
+  const { data, error, fetchData } = useAxios<string>({});
+  const navigate = useNavigate();
+
+  const handleDeleteAccountClick = () => {
+    if (
+      confirm(
+        '정말 키피어피를 탈퇴하시겠습니까? 한 번 탈퇴한 회원의 정보 및 팀 게시글은 영구히 복구되지 않습니다.',
+      )
+    ) {
+      fetchData({ newPath: '/user/', newMethod: 'DELETE' });
+    }
+  };
+  useEffect(() => {
+    if (data) {
+      alert('회원 탈퇴되었습니다.');
+      navigate('/');
+    }
+    if (error) {
+      alert('회원 탈퇴에 실패하였습니다. 관리자에게 문의해주세요.');
+    }
+  }, [data, error]);
+
+  return (
+    <button
+      onClick={handleDeleteAccountClick}
+      className="absolute -bottom-[5.2rem] right-0 text-body3-regular text-black underline underline-offset-2"
+    >
+      회원탈퇴
+    </button>
+  );
+}

--- a/src/components/common/ItemDropDown.tsx
+++ b/src/components/common/ItemDropDown.tsx
@@ -1,11 +1,19 @@
+import clsx from 'clsx';
+
 interface ItemDropDownProps {
   options: string[];
   action: () => void;
+  className?: string;
 }
 
-export default function ItemDropDown({ options, action }: ItemDropDownProps) {
+export default function ItemDropDown({ options, action, className }: ItemDropDownProps) {
   return (
-    <div className="absolute left-0 top-[2.4rem] z-30 flex w-40 flex-col rounded-[0.6rem] bg-[#FCFCFC] py-[0.4rem] shadow-[0px_0px_10px_0px_rgba(17,17,17,0.05)]">
+    <div
+      className={clsx(
+        'absolute left-0 top-[2.4rem] z-30 flex w-40 flex-col rounded-[0.6rem] bg-[#FCFCFC] py-[0.4rem] shadow-[0px_0px_10px_0px_rgba(17,17,17,0.05)]',
+        className,
+      )}
+    >
       {options.map((option) => {
         return (
           <button

--- a/src/components/common/LogoutDropDown.tsx
+++ b/src/components/common/LogoutDropDown.tsx
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import ItemDropDown from './ItemDropDown';
+import { useAxios } from '@/hooks/useAxios';
+
+export default function LogoutDropDown() {
+  const { data, error, fetchData } = useAxios({});
+  const navigate = useNavigate();
+
+  const onLogoutClick = () => {
+    if (confirm('로그아웃 하시겠습니까?')) {
+      fetchData({ newPath: '/auth/logout', newMethod: 'POST' });
+    }
+  };
+
+  useEffect(() => {
+    if (data || error) {
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('refreshToken');
+      alert('로그아웃 되었습니다.');
+      navigate('/');
+    }
+  }, [data, error]); //서버에서 리프레시 삭제 실패해도 일단 로컬에서 토큰 다 없애고 로그아웃 시켜줘야함.
+
+  return (
+    <ItemDropDown
+      options={['로그아웃']}
+      action={onLogoutClick}
+      className="top-[4.5rem] hidden hover:flex peer-hover:flex"
+    ></ItemDropDown>
+  );
+}

--- a/src/components/common/Nav.tsx
+++ b/src/components/common/Nav.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useParams } from 'react-router-dom';
 import InvitationGroupModal from '../Modal/InvitationGroupModal';
+import LogoutDropDown from './LogoutDropDown';
 import NavModal from './NavModal';
 import { useModal } from '@/contexts/ModalProvider';
 import { useUserContext } from '@/contexts/UserProvider';
@@ -129,6 +130,8 @@ function Nav() {
               <ProfileIcon size="lg" />
             </Link>
           )}
+          <div className="peer absolute right-0 top-0 h-[5.4rem] w-[3.6rem]"></div>
+          <LogoutDropDown />
         </div>
       </div>
     </div>

--- a/src/components/common/SelectBoxDropdown.tsx
+++ b/src/components/common/SelectBoxDropdown.tsx
@@ -11,7 +11,7 @@ interface DropDownProps {
   size?: 'sm' | 'md';
 }
 //밸류 받고 위에서 키 찾아 보내는걸로
-export default function Dropdown({
+export default function SelectBoxDropdown({
   options,
   selectedOption,
   initialOption,

--- a/src/components/members/MemberRow.tsx
+++ b/src/components/members/MemberRow.tsx
@@ -2,7 +2,7 @@ import { MEMBER } from '@/constants/Team';
 import { useRef } from 'react';
 import { Control, Controller } from 'react-hook-form';
 import { useParams } from 'react-router-dom';
-import Dropdown from '../common/Dropdown';
+import SelectBoxDropdown from '../common/SelectBoxDropdown';
 import TextButton from '../common/TextButton';
 import { prefixingUsername } from '@/lib/prefixingUsername';
 import { defaultInstance } from '@/hooks/useAxios';
@@ -72,7 +72,7 @@ export default function MemberRow({
             name={String(id)}
             control={control}
             render={({ field }) => (
-              <Dropdown
+              <SelectBoxDropdown
                 options={Object.values(editableGradeOption)}
                 initialOption={MEMBER.GRADE[grade]}
                 selectedOption={field.value}

--- a/src/pages/UserMyPage.tsx
+++ b/src/pages/UserMyPage.tsx
@@ -1,4 +1,5 @@
 import BoardSection from '@/components/common/BoardSection';
+import DeleteAccountButton from '@/components/Mypage/DeleteAccountButton';
 import MyProfileCard from '@/components/Mypage/MyProfileCard';
 import MyTeamHistory from '@/components/Mypage/MyTeamHistory';
 import { ModalProvider } from '@/contexts/ModalProvider';
@@ -8,9 +9,10 @@ export default function UserMyPage() {
     <BoardSection title="Mypage">
       <ModalProvider>
         <div className="mt-[1.8rem] flex h-[51.4rem] flex-col">
-          <div className="flex grow justify-stretch gap-12">
+          <div className="relative flex grow justify-stretch gap-12">
             <MyProfileCard></MyProfileCard>
             <MyTeamHistory></MyTeamHistory>
+            <DeleteAccountButton />
           </div>
         </div>
       </ModalProvider>


### PR DESCRIPTION
## 주요 구현 사항 ✨
1. 회원탈퇴 구현
2. 로그아웃 구현
3. 팀 삭제, 회원 탈퇴 DELETE는 API 수정되면 정상 동작할 것 같습니다 
---
기존에 지선님이 만들어 주신 `ItemDropdown` 컴포넌트 재사용해서 로그아웃 구현했습니다.
디자인 시안에서 프로필 아이콘이랑 드롭다운이랑 갭이 있어서 지선님 ItemDropdown에 classname 부분 추가하고 소은님 navbar에 드롭다운 달리는 부분 추가했습니다 확인해주세요!

<img src="https://github.com/codeit-part4-8team-project/main/assets/121015462/ad2cc992-762b-40fc-ab29-fd65ff94bdc5" width='240' height='240'/>

---
드롭다운 구분지으려고 드롭다운 이름 ui 맞게 바꿨습니다
![image](https://github.com/codeit-part4-8team-project/main/assets/121015462/06fc8bf9-b489-48c2-9208-416ae0b6bc7a)
`Dropdown` > `SelectBoxDropdown`

![image](https://github.com/codeit-part4-8team-project/main/assets/121015462/46c420a2-6c09-46e1-96d4-8ecef0cc7255)
`ItemDropdown`

## 스크린샷 🎨

-

## 구체적 구현 사항 설명 📃

-

## 논의사항 🤔

-
